### PR TITLE
URL Cleanup

### DIFF
--- a/Dalston.SR5/spring-cloud.xml
+++ b/Dalston.SR5/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -340,13 +340,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -375,7 +375,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 </section>
 <section xml:id="_serviceregistry">
@@ -489,7 +489,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -916,14 +916,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -966,20 +966,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1107,15 +1107,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1124,7 +1124,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2001,7 +2001,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2055,7 +2055,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
 <title>Authenticating with the Eureka Server</title>
@@ -2177,7 +2177,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2289,7 +2289,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2424,7 +2424,7 @@ IP Address rather than its hostname.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2448,7 +2448,7 @@ IP Address rather than its hostname.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2543,7 +2543,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2563,7 +2563,7 @@ To make turbine find the Hystrix stream at the correct port, you need to add <li
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2608,7 +2608,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -2812,7 +2812,7 @@ This lazy loading behavior can be changed to instead eagerly load up these child
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3145,7 +3145,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3165,7 +3165,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3208,7 +3208,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3285,7 +3285,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor can you loadbalance multiple URLs with Ribbon.
@@ -3504,7 +3504,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3513,7 +3513,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4030,7 +4030,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -5794,7 +5794,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> setting can be use
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean setting enables the deletion of schema. By default this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>A Spring Boot application enabling the schema registry looks as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -6751,12 +6751,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7079,7 +7079,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -8106,10 +8106,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -8288,7 +8288,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -9479,7 +9479,7 @@ Stream based span reporting).</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -9572,7 +9572,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -9761,7 +9761,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -9860,7 +9860,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -9881,10 +9881,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -9916,7 +9916,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -10026,7 +10026,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded.  Watching the key value store (which Consul supports) is not currently possible, but will be a future addition to this project.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -10138,13 +10138,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -10203,11 +10203,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -10503,7 +10503,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -10722,7 +10722,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -10752,7 +10752,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -10929,7 +10929,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -11273,9 +11273,9 @@ all the contract are present in the producer&#8217;s repository</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -11627,7 +11627,7 @@ You can switch off the value of the <literal>workOffline</literal> parameter in 
 example of achieving the same by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>And that&#8217;s it!</simpara>
 </section>
 </section>
@@ -11650,7 +11650,7 @@ is under constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -11678,7 +11678,7 @@ is under constant development.</simpara>
 <simpara>In order to use Spring Cloud Contract Verifier with WireMock you have to use Gradle or Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects you have to add separately
-the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock docs for more information</link></simpara>
+the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock docs for more information</link></simpara>
 </warning>
 </section>
 <section xml:id="_add_gradle_plugin_with_dependencies">
@@ -11742,9 +11742,9 @@ and will modify the imports accordingly.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -12862,9 +12862,9 @@ automatically for you.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -12909,7 +12909,7 @@ automatically for you.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -12975,7 +12975,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -13000,7 +13000,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -13503,7 +13503,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -13669,7 +13669,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -13853,7 +13853,7 @@ information about the reasons behind this change.</simpara>
 <simpara>Starting from version 1.0.4 as a version you can provide a range of versions that you would like
 the Stub Runner to take into consideration. You can read more about the <link xl:href="https://wiki.eclipse.org/Aether/New_and_Noteworthy#Version_Ranges">Aether versioning ranges here</link>.</simpara>
 </important>
-<simpara>Taken from <link xl:href="http://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
+<simpara>Taken from <link xl:href="https://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
 <blockquote>
 <simpara>This scheme accepts versions of any form, interpreting a version as a sequence of numeric and alphabetic segments. The characters '-', '_', and '.' as well as the mere
 transitions from digit to letter and vice versa delimit the version segments. Delimiters are treated as equivalent.</simpara>
@@ -14145,9 +14145,9 @@ Remember to annotate your test class with <literal>@AutoConfigureStubRunner</lit
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -14506,7 +14506,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -17078,7 +17078,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -17089,7 +17089,7 @@ public class WiremockForDocsMockServerApplicationTests {
 method takes a stub path resource pattern as an argument. So in this
 example the stub defined at <literal>/stubs/resource.json</literal> is loaded into the
 mock server, so if the <literal>RestTemplate</literal> is asked to visit
-<literal><link xl:href="http://example.org/">http://example.org/</link></literal> it will get the responses as declared
+<literal><link xl:href="https://example.org/">https://example.org/</link></literal> it will get the responses as declared
 there. More than one stub pattern can be specified, and each one can
 be a directory (for a recursive list of all ".json"), or a fixed
 filename (like in the example above) or an ant-style pattern. The JSON
@@ -17486,8 +17486,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -17495,7 +17495,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -18814,7 +18814,7 @@ after application shutdown.</simpara>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Edgware.RELEASE/spring-cloud.xml
+++ b/Edgware.RELEASE/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -340,13 +340,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -375,7 +375,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -512,7 +512,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -963,14 +963,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -1013,20 +1013,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1162,15 +1162,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1179,7 +1179,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2078,7 +2078,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2131,7 +2131,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2254,7 +2254,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2391,7 +2391,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2532,7 +2532,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2556,7 +2556,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2651,7 +2651,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2672,7 +2672,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2719,7 +2719,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -3015,7 +3015,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3375,7 +3375,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3395,7 +3395,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3438,7 +3438,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3515,7 +3515,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -3541,7 +3541,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3810,7 +3810,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3819,7 +3819,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4421,7 +4421,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -6317,7 +6317,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> setting can be use
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean setting enables the deletion of schema. By default this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>A Spring Boot application enabling the schema registry looks as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -6987,7 +6987,7 @@ hello world 1458595080735</screen>
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream applications on CloudFoundry</title>
 <simpara>On CloudFoundry services are usually exposed via a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7311,12 +7311,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7467,7 +7467,7 @@ On the other hand, if auto topic creation is disabled on the server, then care m
 <simpara>Spring Cloud Stream Kafka support also includes a binder specifically designed for Kafka Streams binding.
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Kafka Streams API Developer Manual</link></simpara>
-<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
+<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
 <simpara>Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
   &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -7758,7 +7758,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -8895,10 +8895,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -9077,7 +9077,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10171,7 +10171,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -10179,7 +10179,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -10271,7 +10271,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -10460,7 +10460,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -10562,7 +10562,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -10583,10 +10583,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -10618,7 +10618,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -10706,7 +10706,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -10751,7 +10751,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -10863,13 +10863,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -10927,11 +10927,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -11227,7 +11227,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -11446,7 +11446,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -11476,7 +11476,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -11653,7 +11653,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -12027,9 +12027,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -12459,7 +12459,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -12483,7 +12483,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -12710,7 +12710,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -12822,7 +12822,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -12864,7 +12864,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -12898,7 +12898,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -13019,7 +13019,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -13086,9 +13086,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -14361,9 +14361,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -14408,7 +14408,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14474,7 +14474,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -14499,7 +14499,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -15049,7 +15049,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -15215,7 +15215,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -15721,9 +15721,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -16110,7 +16110,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -18764,7 +18764,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -18774,7 +18774,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -19026,7 +19026,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -19347,8 +19347,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -19356,7 +19356,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -20817,7 +20817,7 @@ after application shutdown.</simpara>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Edgware.SR1/spring-cloud.xml
+++ b/Edgware.SR1/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -340,13 +340,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -375,7 +375,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -543,7 +543,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -994,14 +994,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -1044,20 +1044,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1193,15 +1193,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1210,7 +1210,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2109,7 +2109,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2162,7 +2162,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2285,7 +2285,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2422,7 +2422,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2563,7 +2563,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2587,7 +2587,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2682,7 +2682,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2703,7 +2703,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2750,7 +2750,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -3046,7 +3046,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3406,7 +3406,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3426,7 +3426,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3469,7 +3469,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3546,7 +3546,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -3572,7 +3572,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3841,7 +3841,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3850,7 +3850,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4452,7 +4452,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -6348,7 +6348,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> setting can be use
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean setting enables the deletion of schema. By default this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>A Spring Boot application enabling the schema registry looks as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7018,7 +7018,7 @@ hello world 1458595080735</screen>
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream applications on CloudFoundry</title>
 <simpara>On CloudFoundry services are usually exposed via a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7342,12 +7342,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7498,7 +7498,7 @@ On the other hand, if auto topic creation is disabled on the server, then care m
 <simpara>Spring Cloud Stream Kafka support also includes a binder specifically designed for Kafka Streams binding.
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Kafka Streams API Developer Manual</link></simpara>
-<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
+<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
 <simpara>Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
   &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -7789,7 +7789,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -8976,10 +8976,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -9158,7 +9158,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10252,7 +10252,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -10260,7 +10260,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -10353,7 +10353,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -10542,7 +10542,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -10644,7 +10644,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -10665,10 +10665,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -10700,7 +10700,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -10788,7 +10788,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -10833,7 +10833,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -10945,13 +10945,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -11009,11 +11009,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -11309,7 +11309,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -11528,7 +11528,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -11558,7 +11558,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -11735,7 +11735,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -12109,9 +12109,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -12541,7 +12541,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -12565,7 +12565,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -12792,7 +12792,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -12904,7 +12904,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -12946,7 +12946,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -12980,7 +12980,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -13102,7 +13102,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -13169,9 +13169,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -14435,9 +14435,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -14482,7 +14482,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14548,7 +14548,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -14573,7 +14573,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -15123,7 +15123,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -15289,7 +15289,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -15795,9 +15795,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -16184,7 +16184,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -18838,7 +18838,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -18848,7 +18848,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -19114,7 +19114,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -19435,8 +19435,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -19444,7 +19444,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -20905,7 +20905,7 @@ after application shutdown.</simpara>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Edgware.SR2/spring-cloud.xml
+++ b/Edgware.SR2/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -340,13 +340,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -375,7 +375,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -543,7 +543,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -994,14 +994,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -1044,20 +1044,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1193,15 +1193,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1210,7 +1210,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2109,7 +2109,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2162,7 +2162,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2285,7 +2285,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2422,7 +2422,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2563,7 +2563,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2587,7 +2587,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2682,7 +2682,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2703,7 +2703,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2750,7 +2750,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -3046,7 +3046,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3406,7 +3406,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3426,7 +3426,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3469,7 +3469,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3546,7 +3546,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -3572,7 +3572,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3841,7 +3841,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3850,7 +3850,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4486,7 +4486,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -6382,7 +6382,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> setting can be use
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean setting enables the deletion of schema. By default this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>A Spring Boot application enabling the schema registry looks as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7052,7 +7052,7 @@ hello world 1458595080735</screen>
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream applications on CloudFoundry</title>
 <simpara>On CloudFoundry services are usually exposed via a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7376,12 +7376,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7532,7 +7532,7 @@ On the other hand, if auto topic creation is disabled on the server, then care m
 <simpara>Spring Cloud Stream Kafka support also includes a binder specifically designed for Kafka Streams binding.
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Kafka Streams API Developer Manual</link></simpara>
-<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
+<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
 <simpara>Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
   &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -7823,7 +7823,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9010,10 +9010,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -9192,7 +9192,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10287,7 +10287,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -10295,7 +10295,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -10388,7 +10388,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -10577,7 +10577,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -10679,7 +10679,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -10700,10 +10700,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -10735,7 +10735,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -10823,7 +10823,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -10868,7 +10868,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -10980,13 +10980,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -11044,11 +11044,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -11344,7 +11344,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -11563,7 +11563,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -11593,7 +11593,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -11770,7 +11770,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -12206,9 +12206,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -12702,7 +12702,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -12726,7 +12726,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -12957,7 +12957,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -13069,7 +13069,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -13111,7 +13111,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -13145,7 +13145,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -13271,7 +13271,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -13338,9 +13338,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -14261,7 +14261,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -14875,9 +14875,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -14922,7 +14922,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14988,7 +14988,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -15013,7 +15013,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -15563,7 +15563,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -15729,7 +15729,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -16296,9 +16296,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -16684,7 +16684,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -17809,7 +17809,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -19983,7 +19983,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -19993,7 +19993,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -20259,7 +20259,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -20580,8 +20580,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -20589,7 +20589,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -22050,7 +22050,7 @@ after application shutdown.</simpara>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Edgware.SR3/spring-cloud.xml
+++ b/Edgware.SR3/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -340,13 +340,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -375,7 +375,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -543,7 +543,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -994,14 +994,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -1044,20 +1044,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1193,15 +1193,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1232,7 +1232,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2131,7 +2131,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2184,7 +2184,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2307,7 +2307,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2444,7 +2444,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2585,7 +2585,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2609,7 +2609,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2704,7 +2704,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2725,7 +2725,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2772,7 +2772,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -3068,7 +3068,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3428,7 +3428,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3448,7 +3448,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3491,7 +3491,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3568,7 +3568,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -3594,7 +3594,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3863,7 +3863,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3872,7 +3872,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4508,7 +4508,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -6404,7 +6404,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> setting can be use
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean setting enables the deletion of schema. By default this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>A Spring Boot application enabling the schema registry looks as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7074,7 +7074,7 @@ hello world 1458595080735</screen>
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream applications on CloudFoundry</title>
 <simpara>On CloudFoundry services are usually exposed via a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7398,12 +7398,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7554,7 +7554,7 @@ On the other hand, if auto topic creation is disabled on the server, then care m
 <simpara>Spring Cloud Stream Kafka support also includes a binder specifically designed for Kafka Streams binding.
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Kafka Streams API Developer Manual</link></simpara>
-<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
+<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
 <simpara>Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
   &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -7845,7 +7845,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9032,10 +9032,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -9214,7 +9214,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10314,7 +10314,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -10327,7 +10327,7 @@ Example for <literal>web</literal>:</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -10426,7 +10426,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -10615,7 +10615,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -10717,7 +10717,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -10766,10 +10766,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -10801,7 +10801,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -10889,7 +10889,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -10934,7 +10934,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -11046,13 +11046,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -11110,11 +11110,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -11410,7 +11410,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -11629,7 +11629,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -11659,7 +11659,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -11836,7 +11836,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -12272,9 +12272,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -12768,7 +12768,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -12792,7 +12792,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -13023,7 +13023,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -13135,7 +13135,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -13177,7 +13177,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -13211,7 +13211,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -13336,7 +13336,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -13403,9 +13403,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -14294,7 +14294,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -14939,9 +14939,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -14986,7 +14986,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15052,7 +15052,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -15077,7 +15077,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -15646,7 +15646,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -15812,7 +15812,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -16379,9 +16379,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -16767,7 +16767,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -17892,7 +17892,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -20066,7 +20066,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -20076,7 +20076,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -20342,7 +20342,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -20663,8 +20663,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -20672,7 +20672,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -22133,7 +22133,7 @@ after application shutdown.</simpara>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Edgware.SR5/spring-cloud.xml
+++ b/Edgware.SR5/spring-cloud.xml
@@ -50,18 +50,18 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -347,13 +347,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -386,7 +386,7 @@ will also be disabled since they are just a special case of <literal>/restart</l
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -568,7 +568,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>
@@ -1019,14 +1019,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -1069,20 +1069,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -1226,15 +1226,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1265,7 +1265,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">
@@ -2166,7 +2166,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -2219,7 +2219,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2345,7 +2345,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2482,7 +2482,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -2651,7 +2651,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -2675,7 +2675,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -2770,7 +2770,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2791,7 +2791,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -2823,10 +2823,10 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2850,7 +2850,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -3146,7 +3146,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -3506,7 +3506,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -3526,7 +3526,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3569,7 +3569,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -3646,7 +3646,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -3672,7 +3672,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3941,7 +3941,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3950,7 +3950,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -4586,7 +4586,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -6591,7 +6591,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7170,7 +7170,7 @@ hello world 1458595080735</screen>
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream applications on CloudFoundry</title>
 <simpara>On CloudFoundry services are usually exposed via a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow cloudfoundry server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7494,12 +7494,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: security configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, for setting <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS configuration files</title>
@@ -7650,7 +7650,7 @@ On the other hand, if auto topic creation is disabled on the server, then care m
 <simpara>Spring Cloud Stream Kafka support also includes a binder specifically designed for Kafka Streams binding.
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Kafka Streams API Developer Manual</link></simpara>
-<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
+<simpara>Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafaka Streams Support in Spring Kafka</link>.</simpara>
 <simpara>Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
   &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -7941,7 +7941,7 @@ please refer to the <link xl:href="https://github.com/spring-cloud/spring-cloud-
 <section xml:id="rabbit-binder-properties">
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>, and it therefore supports all Spring Boot configuration options for RabbitMQ.
-(For reference, consult the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
+(For reference, consult the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>.)
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9132,10 +9132,10 @@ packages to scan.</simpara>
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -9314,7 +9314,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10423,7 +10423,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL. If you want to disable this feature
 just set <literal>spring.zipkin.discoveryClientEnabled</literal> to <literal>false.
@@ -10465,7 +10465,7 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -10564,7 +10564,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -10753,7 +10753,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -10855,7 +10855,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -10904,10 +10904,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -10939,7 +10939,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -11027,7 +11027,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -11072,7 +11072,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -11184,13 +11184,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -11248,11 +11248,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate_4">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -11548,7 +11548,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev
@@ -11767,7 +11767,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -11797,7 +11797,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -11974,7 +11974,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -12409,9 +12409,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -12904,7 +12904,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -12928,7 +12928,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -13159,7 +13159,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -13271,7 +13271,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -13313,7 +13313,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -13347,7 +13347,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -13472,7 +13472,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -13539,9 +13539,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -14430,7 +14430,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -15075,9 +15075,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -15124,7 +15124,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15190,7 +15190,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -15215,7 +15215,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -15773,7 +15773,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -15939,7 +15939,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -16504,9 +16504,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -16892,7 +16892,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -18061,7 +18061,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -20235,7 +20235,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -20245,7 +20245,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -20511,7 +20511,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -20832,8 +20832,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -20841,7 +20841,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -21836,7 +21836,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -22759,7 +22759,7 @@ EXPOSE 8080</screen>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.service-url</simpara></entry>
 <entry align="left" valign="top"></entry>
-<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
+<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.use-dns-for-fetching-service-urls</simpara></entry>
@@ -24459,7 +24459,7 @@ EXPOSE 8080</screen>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>
 </row>
 <row>

--- a/Finchley.RELEASE/spring-cloud.xml
+++ b/Finchley.RELEASE/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -260,13 +260,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -302,7 +302,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -519,7 +519,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -973,14 +973,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1014,14 +1014,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1152,15 +1152,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1194,7 +1194,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2010,7 +2010,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2047,7 +2047,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2158,7 +2158,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2281,7 +2281,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -2418,7 +2418,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2448,7 +2448,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2547,7 +2547,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2574,7 +2574,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2654,7 +2654,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -2946,7 +2946,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -2973,7 +2973,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3017,7 +3017,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3074,7 +3074,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3100,7 +3100,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3327,7 +3327,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3336,7 +3336,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -3919,7 +3919,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4002,7 +4002,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -5016,7 +5016,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natiural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6461,7 +6461,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -6970,7 +6970,7 @@ For example, specifying <literal>spring.integration.*</literal> captures metric 
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7397,12 +7397,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -7749,7 +7749,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
 provided by the Kafka Streams API is available for use in the business logic, too.</simpara>
@@ -8299,7 +8299,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9711,10 +9711,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -9876,7 +9876,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -9895,7 +9895,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -9907,7 +9907,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10384,7 +10384,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -10500,7 +10500,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11236,7 +11236,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -11279,13 +11279,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -11478,7 +11478,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -11599,7 +11599,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -11639,11 +11639,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -11677,7 +11677,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -11766,7 +11766,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -11818,7 +11818,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -11931,13 +11931,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -11995,7 +11995,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12048,8 +12048,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -12441,7 +12441,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -12693,7 +12693,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -12723,7 +12723,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -12900,7 +12900,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -13152,7 +13152,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -13399,7 +13399,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -13690,9 +13690,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -14187,7 +14187,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -14211,7 +14211,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -14448,7 +14448,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -14560,7 +14560,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -14602,7 +14602,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14636,7 +14636,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15046,7 +15046,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -15330,7 +15330,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -15397,9 +15397,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -16411,7 +16411,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -17056,9 +17056,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -17105,7 +17105,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -17171,7 +17171,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -17205,7 +17205,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -17806,7 +17806,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -17972,7 +17972,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -18425,9 +18425,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -18814,7 +18814,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -20048,7 +20048,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -22538,7 +22538,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -22548,7 +22548,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -22838,7 +22838,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -23167,8 +23167,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -23176,7 +23176,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -24434,7 +24434,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -24448,10 +24448,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -24484,7 +24484,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24502,7 +24502,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24520,7 +24520,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24538,7 +24538,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -24556,7 +24556,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -24574,7 +24574,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -24592,7 +24592,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -24610,7 +24610,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -24629,7 +24629,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -24643,7 +24643,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -24661,7 +24661,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -24748,7 +24748,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -24766,7 +24766,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -24784,7 +24784,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -24795,7 +24795,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -24805,7 +24805,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -24852,7 +24852,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -24870,7 +24870,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -24917,7 +24917,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -24944,7 +24944,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -24965,12 +24965,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -25015,7 +25015,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -25033,7 +25033,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -25051,7 +25051,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -25063,7 +25063,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -25072,14 +25072,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -25151,7 +25151,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -25171,7 +25171,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25189,11 +25189,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -25365,13 +25365,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -25578,7 +25578,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -26427,7 +26427,7 @@ EXPOSE 8080</screen>
  locations.
 </simpara><simpara> Typically the eureka server URLs carry protocol,host,port,context and version
  information if any. Example:
- <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
+ <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link>
 </simpara><simpara> The changes are effective at runtime at the next service url refresh cycle as
  specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>

--- a/Finchley.SR1/spring-cloud.xml
+++ b/Finchley.SR1/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,13 +264,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -306,7 +306,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -523,7 +523,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -977,14 +977,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1018,14 +1018,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1156,15 +1156,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1198,7 +1198,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2014,7 +2014,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2051,7 +2051,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2166,7 +2166,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2289,7 +2289,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -2426,7 +2426,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2456,7 +2456,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2555,7 +2555,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2582,7 +2582,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2651,10 +2651,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2674,7 +2674,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -2966,7 +2966,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -2993,7 +2993,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3037,7 +3037,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3094,7 +3094,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3120,7 +3120,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3347,7 +3347,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3356,7 +3356,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -3939,7 +3939,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4022,7 +4022,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -5036,7 +5036,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natiural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6501,7 +6501,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7014,7 +7014,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7441,12 +7441,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -7793,7 +7793,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
 provided by the Kafka Streams API is available for use in the business logic, too.</simpara>
@@ -8353,7 +8353,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9765,10 +9765,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -9930,7 +9930,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -9949,7 +9949,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -9961,7 +9961,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10441,7 +10441,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -10557,7 +10557,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11293,7 +11293,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -11336,13 +11336,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -11535,7 +11535,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -11656,7 +11656,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -11696,11 +11696,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -11734,7 +11734,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -11823,7 +11823,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -11875,7 +11875,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -11988,13 +11988,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12052,7 +12052,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12105,8 +12105,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -12498,7 +12498,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -12619,7 +12619,7 @@ my.project.DefaultCuratorFrameworkConfig</screen>
 <part xml:id="_spring_boot_cloud_cli">
 <title>Spring Boot Cloud CLI</title>
 <partintro>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do
@@ -12961,7 +12961,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -12991,7 +12991,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13168,7 +13168,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -13420,7 +13420,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -13667,7 +13667,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -13958,9 +13958,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -14454,7 +14454,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -14478,7 +14478,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -14715,7 +14715,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -14827,7 +14827,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -14869,7 +14869,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14903,7 +14903,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15313,7 +15313,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -15597,7 +15597,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -15664,9 +15664,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -16678,7 +16678,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -17321,9 +17321,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -17370,7 +17370,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -17436,7 +17436,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -17470,7 +17470,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -18071,7 +18071,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -18237,7 +18237,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -18690,9 +18690,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -19079,7 +19079,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -20313,7 +20313,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -22858,7 +22858,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -22868,7 +22868,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -23157,7 +23157,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -23466,8 +23466,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -23475,7 +23475,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -24736,7 +24736,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -24750,10 +24750,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -24786,7 +24786,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24804,7 +24804,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24822,7 +24822,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24840,7 +24840,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -24858,7 +24858,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -24876,7 +24876,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -24894,7 +24894,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -24912,7 +24912,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -24931,7 +24931,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -24945,7 +24945,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -24963,7 +24963,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -25050,7 +25050,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -25068,7 +25068,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -25086,7 +25086,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25097,7 +25097,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -25107,7 +25107,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -25154,7 +25154,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -25172,7 +25172,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -25218,7 +25218,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25245,7 +25245,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25266,12 +25266,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -25316,7 +25316,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -25334,7 +25334,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -25352,7 +25352,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -25364,7 +25364,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -25373,14 +25373,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -25452,7 +25452,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -25472,7 +25472,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25490,11 +25490,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -25768,13 +25768,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26004,7 +26004,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -26762,7 +26762,7 @@ EXPOSE 8080</screen>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.service-url</simpara></entry>
 <entry align="left" valign="top"></entry>
-<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
+<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.should-enforce-registration-at-init</simpara></entry>
@@ -28796,7 +28796,7 @@ EXPOSE 8080</screen>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>
 </row>
 <row>

--- a/Finchley.SR2/spring-cloud.xml
+++ b/Finchley.SR2/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,13 +264,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -306,7 +306,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -533,7 +533,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -987,14 +987,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1028,14 +1028,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1166,15 +1166,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1216,7 +1216,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2049,7 +2049,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2086,7 +2086,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2201,7 +2201,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2324,7 +2324,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -2494,7 +2494,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2524,7 +2524,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2623,7 +2623,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2650,7 +2650,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2719,10 +2719,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2742,7 +2742,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3034,7 +3034,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3061,7 +3061,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3105,7 +3105,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3162,7 +3162,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3188,7 +3188,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3415,7 +3415,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3424,7 +3424,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -4007,7 +4007,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4091,7 +4091,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -5097,7 +5097,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natiural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6562,7 +6562,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7075,7 +7075,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7502,12 +7502,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -7854,7 +7854,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
 provided by the Kafka Streams API is available for use in the business logic, too.</simpara>
@@ -8414,7 +8414,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -9826,10 +9826,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -9991,7 +9991,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10010,7 +10010,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10022,7 +10022,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10503,7 +10503,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -10630,7 +10630,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11384,7 +11384,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -11427,13 +11427,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -11632,7 +11632,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -11753,7 +11753,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -11793,11 +11793,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -11831,7 +11831,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -11920,7 +11920,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -11972,7 +11972,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12085,13 +12085,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12149,7 +12149,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12202,8 +12202,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -12595,7 +12595,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -12716,7 +12716,7 @@ my.project.DefaultCuratorFrameworkConfig</screen>
 <part xml:id="_spring_boot_cloud_cli">
 <title>Spring Boot Cloud CLI</title>
 <partintro>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do
@@ -13058,7 +13058,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13088,7 +13088,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13265,7 +13265,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -13517,7 +13517,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -13763,7 +13763,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14052,9 +14052,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -14547,7 +14547,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -14571,7 +14571,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -14808,7 +14808,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -14920,7 +14920,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -14962,7 +14962,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -14996,7 +14996,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15414,7 +15414,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -15698,7 +15698,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -15765,9 +15765,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -16779,7 +16779,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -17422,9 +17422,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -17471,7 +17471,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -17537,7 +17537,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -17571,7 +17571,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -18161,7 +18161,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -18327,7 +18327,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -18778,9 +18778,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -19167,7 +19167,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -20401,7 +20401,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -22976,7 +22976,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -22986,7 +22986,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -23275,7 +23275,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -23584,15 +23584,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -24853,7 +24853,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -24867,10 +24867,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -24903,7 +24903,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24921,7 +24921,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24939,7 +24939,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -24957,7 +24957,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -24975,7 +24975,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -24993,7 +24993,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -25011,7 +25011,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -25029,7 +25029,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -25048,7 +25048,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -25062,7 +25062,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -25080,7 +25080,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -25167,7 +25167,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -25185,7 +25185,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -25203,7 +25203,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25214,7 +25214,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -25224,7 +25224,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -25271,7 +25271,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -25289,7 +25289,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -25335,7 +25335,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25362,7 +25362,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25383,12 +25383,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -25433,7 +25433,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -25451,7 +25451,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -25469,7 +25469,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -25481,7 +25481,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -25490,14 +25490,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -25569,7 +25569,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -25589,7 +25589,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25607,11 +25607,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -25903,13 +25903,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26139,7 +26139,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -26902,7 +26902,7 @@ EXPOSE 8080</screen>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.service-url</simpara></entry>
 <entry align="left" valign="top"></entry>
-<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
+<entry align="left" valign="top"><simpara>Map of availability zone to list of fully qualified URLs to communicate with eureka server. Each value can be a single URL or a comma separated list of alternative locations. Typically the eureka server URLs carry protocol,host,port,context and version information if any. Example: <link xl:href="https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/">https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/</link> The changes are effective at runtime at the next service url refresh cycle as specified by eurekaServiceUrlPollIntervalSeconds.</simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>eureka.client.should-enforce-registration-at-init</simpara></entry>
@@ -29005,7 +29005,7 @@ EXPOSE 8080</screen>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>
 </row>
 <row>

--- a/Greenwich.M3/spring-cloud.xml
+++ b/Greenwich.M3/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,13 +269,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -311,7 +311,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -550,7 +550,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -1039,14 +1039,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1080,14 +1080,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1218,15 +1218,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1268,7 +1268,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2105,7 +2105,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2142,7 +2142,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2257,7 +2257,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2380,7 +2380,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -2550,7 +2550,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2580,7 +2580,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2679,7 +2679,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2706,7 +2706,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2775,10 +2775,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2798,7 +2798,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3090,7 +3090,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3117,7 +3117,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3161,7 +3161,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3218,7 +3218,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3244,7 +3244,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3471,7 +3471,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3480,7 +3480,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -3701,12 +3701,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -4080,7 +4080,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4164,7 +4164,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -4543,7 +4543,7 @@ the proxy will not try to contact the service.</literallayout>
 <title>Spring Cloud Stream</title>
 <chapter xml:id="_a_brief_history_of_spring_s_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -5191,7 +5191,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6766,7 +6766,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7279,7 +7279,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7734,12 +7734,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -8086,7 +8086,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -8705,7 +8705,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -10181,10 +10181,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -10346,7 +10346,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10365,7 +10365,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10377,7 +10377,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10857,7 +10857,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -10984,7 +10984,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11769,7 +11769,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -11812,13 +11812,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -12020,7 +12020,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -12147,7 +12147,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -12202,11 +12202,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -12240,7 +12240,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -12358,7 +12358,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -12410,7 +12410,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12523,13 +12523,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12587,7 +12587,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12640,8 +12640,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -13033,7 +13033,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -13284,7 +13284,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13314,7 +13314,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13491,7 +13491,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -13746,7 +13746,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14015,7 +14015,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14304,9 +14304,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -14799,7 +14799,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -14823,7 +14823,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -15060,7 +15060,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -15172,7 +15172,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -15214,7 +15214,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15248,7 +15248,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15605,7 +15605,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -15889,7 +15889,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -15956,9 +15956,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -17004,7 +17004,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -17647,9 +17647,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -17696,7 +17696,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -17762,7 +17762,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -17796,7 +17796,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -18411,7 +18411,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -18577,7 +18577,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -19137,9 +19137,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -20654,7 +20654,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -23244,7 +23244,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -23255,7 +23255,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -23543,7 +23543,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -23848,15 +23848,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -25286,7 +25286,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -25300,10 +25300,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -25336,7 +25336,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25354,7 +25354,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25372,7 +25372,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25390,7 +25390,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -25408,7 +25408,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -25426,7 +25426,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -25444,7 +25444,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -25462,7 +25462,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -25481,7 +25481,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -25495,7 +25495,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -25513,7 +25513,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -25600,7 +25600,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -25618,7 +25618,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -25636,7 +25636,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25647,7 +25647,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -25657,7 +25657,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -25787,7 +25787,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -25805,7 +25805,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -25851,7 +25851,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25878,7 +25878,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -25899,12 +25899,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -25949,7 +25949,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -25967,7 +25967,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -25985,7 +25985,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -26005,7 +26005,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -26015,7 +26015,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -26024,14 +26024,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -26103,7 +26103,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -26123,7 +26123,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26141,11 +26141,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26463,13 +26463,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26722,7 +26722,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -27353,8 +27353,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <title>DiscoveryClient for Kubernetes</title>
 <partintro>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -27391,7 +27391,7 @@ variables.</simpara>
 </partintro>
 <chapter xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -28002,7 +28002,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -28026,13 +28026,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -28089,7 +28089,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -28116,7 +28116,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -30516,7 +30516,7 @@ message (where XXXX is the issue number).</simpara>
 <row>
 <entry align="left" valign="top"><simpara>Mount path of the AWS-EC2 authentication backend.</simpara></entry>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>

--- a/Greenwich.RC1/spring-cloud.xml
+++ b/Greenwich.RC1/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,13 +269,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -311,7 +311,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -550,7 +550,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -1039,14 +1039,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1080,14 +1080,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1218,15 +1218,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1268,7 +1268,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2105,7 +2105,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2142,7 +2142,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2257,7 +2257,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2380,7 +2380,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -2582,7 +2582,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2612,7 +2612,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2711,7 +2711,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2738,7 +2738,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2807,10 +2807,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2830,7 +2830,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3123,7 +3123,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3150,7 +3150,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3194,7 +3194,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3251,7 +3251,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3277,7 +3277,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3504,7 +3504,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3513,7 +3513,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -3751,12 +3751,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -4130,7 +4130,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4214,7 +4214,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -4608,7 +4608,7 @@ public class DemoTemplate {
 <title>Spring Cloud Stream</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -5256,7 +5256,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6831,7 +6831,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7344,7 +7344,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7799,12 +7799,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -8151,7 +8151,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -8770,7 +8770,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -10246,10 +10246,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -10411,7 +10411,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10430,7 +10430,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10442,7 +10442,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10922,7 +10922,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -11049,7 +11049,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11835,7 +11835,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -11878,13 +11878,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -12086,7 +12086,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -12247,7 +12247,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -12302,11 +12302,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -12340,7 +12340,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -12458,7 +12458,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -12510,7 +12510,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12623,13 +12623,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12687,7 +12687,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12740,8 +12740,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -13133,7 +13133,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -13384,7 +13384,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13414,7 +13414,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13591,7 +13591,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -13846,7 +13846,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14115,7 +14115,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14404,9 +14404,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -14899,7 +14899,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -14923,7 +14923,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -15160,7 +15160,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -15272,7 +15272,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -15314,7 +15314,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15348,7 +15348,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15705,7 +15705,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -15989,7 +15989,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -16056,9 +16056,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -17065,7 +17065,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -17708,9 +17708,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -17757,7 +17757,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -17823,7 +17823,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -17857,7 +17857,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -18474,7 +18474,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -18640,7 +18640,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -19200,9 +19200,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -20834,7 +20834,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -23402,7 +23402,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -23413,7 +23413,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -23701,7 +23701,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -24006,15 +24006,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -25444,7 +25444,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -25458,10 +25458,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -25494,7 +25494,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25512,7 +25512,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25530,7 +25530,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25548,7 +25548,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -25566,7 +25566,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -25584,7 +25584,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -25604,7 +25604,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -25622,7 +25622,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -25645,7 +25645,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -25659,7 +25659,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -25677,7 +25677,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -25764,7 +25764,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -25782,7 +25782,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -25800,7 +25800,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -25811,7 +25811,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -25821,7 +25821,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -25951,7 +25951,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -25969,7 +25969,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -26016,7 +26016,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26043,7 +26043,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26064,12 +26064,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -26114,7 +26114,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -26132,7 +26132,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -26150,7 +26150,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -26170,7 +26170,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -26180,7 +26180,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -26189,14 +26189,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -26268,7 +26268,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -26288,7 +26288,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26306,11 +26306,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26630,13 +26630,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -26717,7 +26717,7 @@ public RouteLocator customRouteLocator(RouteLocatorBuilder builder, ThrottleGate
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -26835,7 +26835,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>
@@ -27103,7 +27103,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -27732,8 +27732,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -27767,7 +27767,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -28374,7 +28374,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -28407,7 +28407,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -28431,13 +28431,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -28494,7 +28494,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -28521,7 +28521,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -28587,7 +28587,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>GCP Support</simpara>
@@ -28801,7 +28801,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -28926,7 +28926,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -29872,7 +29872,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <simpara>A <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample">sample application</link> is available.</simpara>
 <section xml:id="_web_mvc_interceptor">
@@ -30150,7 +30150,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Also note that core properties as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link> do not apply to Spring Cloud GCP Config.</simpara>
@@ -30194,7 +30194,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -30224,7 +30224,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -30235,8 +30235,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -31457,8 +31457,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -32613,7 +32613,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, then you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>
@@ -35062,7 +35062,7 @@ Otherwise, Cloud Foundry will produce a <literal>DataSource</literal> with an in
 <row>
 <entry align="left" valign="top"><simpara>Mount path of the AWS-EC2 authentication backend.</simpara></entry>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>

--- a/Greenwich.RC2/spring-cloud.xml
+++ b/Greenwich.RC2/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,13 +269,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -311,7 +311,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -550,7 +550,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -1039,14 +1039,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1080,14 +1080,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1218,15 +1218,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1268,7 +1268,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2190,7 +2190,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2227,7 +2227,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2342,7 +2342,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2465,7 +2465,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -2667,7 +2667,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2697,7 +2697,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2796,7 +2796,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2823,7 +2823,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2892,10 +2892,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2915,7 +2915,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3207,7 +3207,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3234,7 +3234,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3278,7 +3278,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3335,7 +3335,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3361,7 +3361,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3588,7 +3588,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3597,7 +3597,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -3835,12 +3835,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -4214,7 +4214,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4338,7 +4338,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -4732,7 +4732,7 @@ public class DemoTemplate {
 <title>Spring Cloud Stream</title>
 <chapter xml:id="_a_brief_history_of_spring_s_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -5380,7 +5380,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6955,7 +6955,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7468,7 +7468,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7923,12 +7923,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -8275,7 +8275,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -8894,7 +8894,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -10370,10 +10370,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -10535,7 +10535,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10554,7 +10554,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10566,7 +10566,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -11045,7 +11045,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -11172,7 +11172,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -11959,7 +11959,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -12002,13 +12002,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -12211,7 +12211,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -12379,7 +12379,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -12434,11 +12434,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -12472,7 +12472,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -12662,7 +12662,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -12714,7 +12714,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12827,13 +12827,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12891,7 +12891,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -12944,8 +12944,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -13337,7 +13337,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -13588,7 +13588,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13676,7 +13676,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13853,7 +13853,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -14108,7 +14108,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14377,7 +14377,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14666,9 +14666,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -15160,7 +15160,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -15184,7 +15184,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -15421,7 +15421,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -15533,7 +15533,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -15575,7 +15575,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15609,7 +15609,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -15966,7 +15966,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -16250,7 +16250,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -16317,9 +16317,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -17379,7 +17379,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -18022,9 +18022,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -18071,7 +18071,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -18137,7 +18137,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -18171,7 +18171,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -18786,7 +18786,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -18952,7 +18952,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -19512,9 +19512,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -21195,7 +21195,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -23842,7 +23842,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -23853,7 +23853,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -24141,7 +24141,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -24446,15 +24446,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -25884,7 +25884,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -25898,10 +25898,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -25934,7 +25934,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25952,7 +25952,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25970,7 +25970,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -25988,7 +25988,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -26006,7 +26006,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -26024,7 +26024,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -26044,7 +26044,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -26062,7 +26062,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -26085,7 +26085,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -26099,7 +26099,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -26117,7 +26117,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -26204,7 +26204,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -26222,7 +26222,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -26240,7 +26240,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26251,7 +26251,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -26261,7 +26261,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -26391,7 +26391,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -26409,7 +26409,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -26456,7 +26456,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26483,7 +26483,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26504,12 +26504,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -26554,7 +26554,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -26572,7 +26572,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -26590,7 +26590,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -26610,7 +26610,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -26620,7 +26620,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -26629,14 +26629,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -26708,7 +26708,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -26728,7 +26728,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26746,11 +26746,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27122,13 +27122,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27236,7 +27236,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -27354,7 +27354,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>
@@ -27622,7 +27622,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -28253,8 +28253,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -28303,7 +28303,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -28838,7 +28838,7 @@ within the Kubernetes platform <emphasis role="strong">(e.g. different dev and p
 <section xml:id="_istio_awareness">
 <title>Istio Awareness</title>
 <simpara>When including the <emphasis role="strong">spring-cloud-kubernetes-istio</emphasis> module into the application classpath a new profile will be added to the application,
-if the application is running inside a Kubernetes Cluster with <link xl:href="http://istio.io">Istio</link> installed. Then you can use
+if the application is running inside a Kubernetes Cluster with <link xl:href="https://istio.io">Istio</link> installed. Then you can use
 spring <emphasis role="strong">@Profile("istio")</emphasis> annotations into your Beans and <emphasis role="strong">@Configuration</emphasis>'s.</simpara>
 <simpara>The Istio awareness module uses the <emphasis role="strong">me.snowdrop:istio-client</emphasis> to interact with Istio APIs enabling us to discover traffic rules, circuit breakers, etc.
 Making it easy for our Spring Boot applications to consume this data to dynamically configure themselves according the environment.</simpara>
@@ -28923,7 +28923,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -28956,7 +28956,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -28980,13 +28980,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -29043,7 +29043,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -29070,7 +29070,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -29136,7 +29136,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>GCP Support</simpara>
@@ -29354,7 +29354,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pub_sub">
@@ -29479,7 +29479,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -30431,7 +30431,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <simpara>A <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample">sample application</link> is available.</simpara>
 <section xml:id="_web_mvc_interceptor">
@@ -30709,7 +30709,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Also note that core properties as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link> do not apply to Spring Cloud GCP Config.</simpara>
@@ -30753,7 +30753,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -30783,7 +30783,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -30794,8 +30794,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -31996,8 +31996,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -33168,7 +33168,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, then you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>
@@ -35742,7 +35742,7 @@ Otherwise, Cloud Foundry will produce a <literal>DataSource</literal> with an in
 <row>
 <entry align="left" valign="top"><simpara>Mount path of the AWS-EC2 authentication backend.</simpara></entry>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>

--- a/Greenwich.RELEASE/spring-cloud.xml
+++ b/Greenwich.RELEASE/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,13 +269,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -311,7 +311,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -550,7 +550,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -1039,14 +1039,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1080,14 +1080,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1218,15 +1218,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1268,7 +1268,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2190,7 +2190,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2227,7 +2227,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2342,7 +2342,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2465,7 +2465,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -2667,7 +2667,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2697,7 +2697,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2796,7 +2796,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2823,7 +2823,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2892,10 +2892,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2915,7 +2915,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3207,7 +3207,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3234,7 +3234,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3278,7 +3278,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3335,7 +3335,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3361,7 +3361,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3588,7 +3588,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3597,7 +3597,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -3835,12 +3835,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -4214,7 +4214,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4338,7 +4338,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -4751,7 +4751,7 @@ public class DemoTemplate {
 <title>Spring Cloud Stream</title>
 <chapter xml:id="_a_brief_history_of_spring_s_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -5399,7 +5399,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6974,7 +6974,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7487,7 +7487,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7942,12 +7942,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -8294,7 +8294,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -8913,7 +8913,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -10389,10 +10389,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -10554,7 +10554,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10573,7 +10573,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10585,7 +10585,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -11116,7 +11116,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -11243,7 +11243,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -12031,7 +12031,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -12074,13 +12074,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -12283,7 +12283,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -12451,7 +12451,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -12506,11 +12506,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -12544,7 +12544,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -12734,7 +12734,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -12786,7 +12786,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12899,13 +12899,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12963,7 +12963,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -13016,8 +13016,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -13409,7 +13409,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -13660,7 +13660,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13748,7 +13748,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13925,7 +13925,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -14180,7 +14180,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14449,7 +14449,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14738,9 +14738,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -15234,7 +15234,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -15258,7 +15258,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -15495,7 +15495,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -15607,7 +15607,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -15649,7 +15649,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15683,7 +15683,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -16190,7 +16190,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -16474,7 +16474,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -16541,9 +16541,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -17622,7 +17622,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -18265,9 +18265,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -18314,7 +18314,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -18380,7 +18380,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -18414,7 +18414,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -19089,7 +19089,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -19255,7 +19255,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -19815,9 +19815,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -21498,7 +21498,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -24322,7 +24322,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -24333,7 +24333,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -24621,7 +24621,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -24926,15 +24926,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -26364,7 +26364,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -26378,10 +26378,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -26414,7 +26414,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26432,7 +26432,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26450,7 +26450,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26468,7 +26468,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -26486,7 +26486,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -26504,7 +26504,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -26524,7 +26524,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -26542,7 +26542,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -26565,7 +26565,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -26579,7 +26579,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -26597,7 +26597,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -26684,7 +26684,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -26702,7 +26702,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -26720,7 +26720,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26731,7 +26731,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -26741,7 +26741,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -26871,7 +26871,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -26889,7 +26889,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -26936,7 +26936,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26963,7 +26963,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -26984,12 +26984,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -27034,7 +27034,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -27052,7 +27052,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -27070,7 +27070,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -27090,7 +27090,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -27100,7 +27100,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -27109,14 +27109,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -27188,7 +27188,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -27208,7 +27208,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -27226,11 +27226,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27615,13 +27615,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27729,7 +27729,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -27847,7 +27847,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>
@@ -28115,7 +28115,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -28746,8 +28746,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -28796,7 +28796,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -29340,7 +29340,7 @@ within the Kubernetes platform <emphasis role="strong">(e.g. different dev and p
 <section xml:id="_istio_awareness">
 <title>Istio Awareness</title>
 <simpara>When including the <emphasis role="strong">spring-cloud-kubernetes-istio</emphasis> module into the application classpath a new profile will be added to the application,
-if the application is running inside a Kubernetes Cluster with <link xl:href="http://istio.io">Istio</link> installed. Then you can use
+if the application is running inside a Kubernetes Cluster with <link xl:href="https://istio.io">Istio</link> installed. Then you can use
 spring <emphasis role="strong">@Profile("istio")</emphasis> annotations into your Beans and <emphasis role="strong">@Configuration</emphasis>'s.</simpara>
 <simpara>The Istio awareness module uses the <emphasis role="strong">me.snowdrop:istio-client</emphasis> to interact with Istio APIs enabling us to discover traffic rules, circuit breakers, etc.
 Making it easy for our Spring Boot applications to consume this data to dynamically configure themselves according the environment.</simpara>
@@ -29425,7 +29425,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -29458,7 +29458,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -29482,13 +29482,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -29545,7 +29545,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -29572,7 +29572,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -29647,7 +29647,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
 <section xml:id="_gcp_support">
 <title>GCP Support</title>
 <simpara>The GCP Support entry contains auto-configuration support for every Spring Cloud GCP integration.
@@ -29871,7 +29871,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pub_sub">
@@ -29997,7 +29997,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -30947,7 +30947,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <section xml:id="_web_mvc_interceptor">
 <title>Web MVC Interceptor</title>
@@ -31228,7 +31228,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Core properties, as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link>, do not apply to Spring Cloud GCP Config.</simpara>
@@ -31274,7 +31274,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -31304,7 +31304,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -31315,8 +31315,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -32529,8 +32529,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -33712,7 +33712,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>
@@ -36321,7 +36321,7 @@ Based on your build system, you will need to include the correct Kotlin build pl
 <row>
 <entry align="left" valign="top"><simpara>Mount path of the AWS-EC2 authentication backend.</simpara></entry>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 </row>
 <row>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>

--- a/Greenwich.SR1/spring-cloud.xml
+++ b/Greenwich.SR1/spring-cloud.xml
@@ -50,23 +50,23 @@ and extensibility mechanism to cover others.</simpara>
 <part xml:id="_cloud_native_applications">
 <title>Cloud Native Applications</title>
 <partintro>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,13 +269,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -311,7 +311,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -550,7 +550,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>
@@ -1040,14 +1040,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -1081,14 +1081,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -1219,15 +1219,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -1269,7 +1269,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
@@ -2200,7 +2200,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -2237,7 +2237,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>. Eureka Discovery Client will also be disabled when <literal>spring.cloud.discovery.enabled</literal> is set to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -2352,7 +2352,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -2475,7 +2475,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -2666,7 +2666,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -2696,7 +2696,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -2795,7 +2795,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -2822,7 +2822,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -2891,10 +2891,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -2914,7 +2914,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -3211,7 +3211,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -3238,7 +3238,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -3282,7 +3282,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -3339,7 +3339,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -3365,7 +3365,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -3592,7 +3592,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -3601,7 +3601,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -3839,12 +3839,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -4219,7 +4219,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:
@@ -4343,7 +4343,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
@@ -4756,7 +4756,7 @@ public class DemoTemplate {
 <title>Spring Cloud Stream</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -5404,7 +5404,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -6979,7 +6979,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -7492,7 +7492,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -7947,12 +7947,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -8299,7 +8299,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -8918,7 +8918,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -10394,10 +10394,10 @@ public class BusConfiguration {
 </partintro>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -10559,7 +10559,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -10578,7 +10578,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -10590,7 +10590,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -11121,7 +11121,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -11248,7 +11248,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -12038,7 +12038,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -12081,13 +12081,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -12293,7 +12293,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -12468,7 +12468,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -12523,11 +12523,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>
@@ -12561,7 +12561,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -12751,7 +12751,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -12803,7 +12803,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -12916,13 +12916,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>
@@ -12980,7 +12980,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </partintro>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -13033,8 +13033,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -13426,7 +13426,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.
@@ -13677,7 +13677,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -13765,7 +13765,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like
@@ -13946,7 +13946,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry
@@ -14201,7 +14201,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14470,7 +14470,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -14774,9 +14774,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -15303,7 +15303,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -15327,7 +15327,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -15565,7 +15565,7 @@ one to one to the contents of the repo.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -15679,7 +15679,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -15723,7 +15723,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -15757,7 +15757,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -16267,7 +16267,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -16551,7 +16551,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -16618,9 +16618,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -17660,7 +17660,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -18303,9 +18303,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -18352,7 +18352,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -18418,7 +18418,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -18452,7 +18452,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -19186,7 +19186,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -19353,7 +19353,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">* -Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">* -Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 * -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 * -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.
 * springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.
@@ -19924,9 +19924,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xmlns="http://www.springframework.org/schema/integration"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -21631,7 +21631,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -24479,7 +24479,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -24490,7 +24490,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -24778,7 +24778,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -25083,15 +25083,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication_2">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>
@@ -26521,7 +26521,7 @@ after application shutdown.</simpara>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -26544,10 +26544,10 @@ working with Spring Cloud Gateway.</simpara>
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -26580,7 +26580,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26598,7 +26598,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26616,7 +26616,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -26634,7 +26634,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -26652,7 +26652,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -26670,7 +26670,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -26690,7 +26690,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -26708,7 +26708,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -26731,7 +26731,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -26745,7 +26745,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -26763,7 +26763,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -26850,7 +26850,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -26868,7 +26868,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -26886,7 +26886,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -26897,7 +26897,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -26907,7 +26907,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -27037,7 +27037,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -27055,7 +27055,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -27102,7 +27102,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -27129,7 +27129,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -27150,12 +27150,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removehopbyhopheadersfilter_gatewayfilter_factory">
 <title>RemoveHopByHopHeadersFilter GatewayFilter Factory</title>
@@ -27200,7 +27200,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -27218,7 +27218,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -27239,7 +27239,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -27259,7 +27259,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -27269,7 +27269,7 @@ and have it applied to all routes.</simpara>
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -27278,14 +27278,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -27357,7 +27357,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -27377,7 +27377,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -27395,11 +27395,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27800,13 +27800,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -27914,7 +27914,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -28032,7 +28032,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>
@@ -28326,7 +28326,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>
@@ -29777,7 +29777,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -29801,13 +29801,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -29864,7 +29864,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -29891,7 +29891,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -29984,7 +29984,7 @@ message (where XXXX is the issue number).</simpara>
 <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
 &lt;suppressions&gt;
 	&lt;suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/&gt;
 	&lt;suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/&gt;
@@ -30151,7 +30151,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
 <section xml:id="_gcp_support">
 <title>GCP Support</title>
 <simpara>The GCP Support entry contains auto-configuration support for every Spring Cloud GCP integration.
@@ -30375,7 +30375,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -30501,7 +30501,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -31451,7 +31451,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <section xml:id="_web_mvc_interceptor">
 <title>Web MVC Interceptor</title>
@@ -31732,7 +31732,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Core properties, as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link>, do not apply to Spring Cloud GCP Config.</simpara>
@@ -31778,7 +31778,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -31808,7 +31808,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -31819,8 +31819,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -33033,8 +33033,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -34216,7 +34216,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>
@@ -37669,7 +37669,7 @@ Based on your build system, you will need to include the correct Kotlin build pl
 </row>
 <row>
 <entry align="left" valign="top"><simpara>spring.cloud.vault.aws-ec2.identity-document</simpara></entry>
-<entry align="left" valign="top"><simpara><link xl:href="http://169.254.169.254/latest/dynamic/instance-identity/pkcs7">http://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
+<entry align="left" valign="top"><simpara><link xl:href="https://169.254.169.254/latest/dynamic/instance-identity/pkcs7">https://169.254.169.254/latest/dynamic/instance-identity/pkcs7</link></simpara></entry>
 <entry align="left" valign="top"><simpara>URL of the AWS-EC2 PKCS7 identity document.</simpara></entry>
 </row>
 <row>

--- a/spring-cloud-aws/1.2.2.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/1.2.2.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -73,7 +73,7 @@ point-to-point communication. Publish-subscribe messaging is supported with the 
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -90,7 +90,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -113,9 +113,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -162,7 +162,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -191,7 +191,7 @@ errors if the properties are not configured at all.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -209,7 +209,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -331,7 +331,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -392,7 +392,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -401,7 +401,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -443,7 +443,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -546,7 +546,7 @@ the specified region and security credentials. Application developers can inject
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -589,7 +589,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -710,7 +710,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -782,9 +782,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -851,7 +851,7 @@ sophisticated <literal>MessageConverter</literal> that converts objects into JSO
 <programlisting language="java" linenumbering="unnumbered">this.queueMessagingTemplate.convertAndSend("queueName", new Person("John, "Doe"));</programlisting>
 <simpara>In this example a <literal>QueueMessagingTemplate</literal> is created using the messaging namespace. The <literal>convertAndSend</literal> method
 converts the payload <literal>Person</literal> using the configured <literal>MessageConverter</literal> and sends the message.
-Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1068,10 +1068,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1102,9 +1102,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1117,7 +1117,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1194,7 +1194,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1228,7 +1228,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1264,7 +1264,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1281,7 +1281,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1318,7 +1318,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1416,14 +1416,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1461,7 +1461,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1566,9 +1566,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1583,7 +1583,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1639,7 +1639,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1672,7 +1672,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1687,16 +1687,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1707,7 +1707,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1757,7 +1757,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/1.2.3.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/1.2.3.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -73,7 +73,7 @@ point-to-point communication. Publish-subscribe messaging is supported with the 
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -90,7 +90,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -113,9 +113,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -162,7 +162,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -191,7 +191,7 @@ errors if the properties are not configured at all.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -209,7 +209,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -331,7 +331,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -392,7 +392,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -401,7 +401,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -443,7 +443,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -546,7 +546,7 @@ the specified region and security credentials. Application developers can inject
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -589,7 +589,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -710,7 +710,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -782,9 +782,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -851,7 +851,7 @@ sophisticated <literal>MessageConverter</literal> that converts objects into JSO
 <programlisting language="java" linenumbering="unnumbered">this.queueMessagingTemplate.convertAndSend("queueName", new Person("John, "Doe"));</programlisting>
 <simpara>In this example a <literal>QueueMessagingTemplate</literal> is created using the messaging namespace. The <literal>convertAndSend</literal> method
 converts the payload <literal>Person</literal> using the configured <literal>MessageConverter</literal> and sends the message.
-Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1068,10 +1068,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1102,9 +1102,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1117,7 +1117,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1194,7 +1194,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1228,7 +1228,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1264,7 +1264,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1281,7 +1281,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1318,7 +1318,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1416,14 +1416,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1461,7 +1461,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1566,9 +1566,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1583,7 +1583,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1639,7 +1639,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1672,7 +1672,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1687,16 +1687,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1707,7 +1707,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1757,7 +1757,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.0.0.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.0.0.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -77,7 +77,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -94,7 +94,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -102,7 +102,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -117,9 +117,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -169,7 +169,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -200,7 +200,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -208,7 +208,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -226,7 +226,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -353,7 +353,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -414,7 +414,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -423,7 +423,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -465,7 +465,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -673,7 +673,7 @@ AWS parameter values are limited to 4096 characters, so we support individual Sp
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -716,7 +716,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -837,7 +837,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -909,9 +909,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -970,7 +970,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1187,10 +1187,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1221,9 +1221,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1236,7 +1236,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1313,7 +1313,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1347,7 +1347,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1383,7 +1383,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1400,7 +1400,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1437,7 +1437,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1535,14 +1535,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1580,7 +1580,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1685,9 +1685,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1702,7 +1702,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1758,7 +1758,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1791,7 +1791,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1806,16 +1806,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1826,7 +1826,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1876,7 +1876,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.0.1.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.0.1.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -81,7 +81,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -106,7 +106,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -121,9 +121,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -173,7 +173,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -204,7 +204,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -212,7 +212,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -230,7 +230,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -357,7 +357,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -418,7 +418,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -427,7 +427,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -469,7 +469,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -773,7 +773,7 @@ underscore.</simpara>
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -816,7 +816,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -937,7 +937,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -1009,9 +1009,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -1070,7 +1070,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1287,10 +1287,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1321,9 +1321,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1336,7 +1336,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1413,7 +1413,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1447,7 +1447,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1483,7 +1483,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1500,7 +1500,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1537,7 +1537,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1635,14 +1635,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1680,7 +1680,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1785,9 +1785,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1802,7 +1802,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1858,7 +1858,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1891,7 +1891,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1906,16 +1906,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1926,7 +1926,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1976,7 +1976,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.0.2.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.0.2.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -81,7 +81,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -106,7 +106,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -121,9 +121,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -173,7 +173,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -204,7 +204,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -212,7 +212,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -230,7 +230,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -357,7 +357,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -418,7 +418,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -427,7 +427,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -469,7 +469,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -773,7 +773,7 @@ underscore.</simpara>
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -816,7 +816,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -937,7 +937,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -1009,9 +1009,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -1070,7 +1070,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1287,10 +1287,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1321,9 +1321,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1336,7 +1336,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1413,7 +1413,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1447,7 +1447,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1483,7 +1483,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1500,7 +1500,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1537,7 +1537,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1635,14 +1635,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1680,7 +1680,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1785,9 +1785,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1802,7 +1802,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1858,7 +1858,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1891,7 +1891,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1906,16 +1906,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1926,7 +1926,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1976,7 +1976,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.1.0.RC1/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.1.0.RC1/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -81,7 +81,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -106,7 +106,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -121,9 +121,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -173,7 +173,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -204,7 +204,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -212,7 +212,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -230,7 +230,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -357,7 +357,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -418,7 +418,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -427,7 +427,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -469,7 +469,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -773,7 +773,7 @@ underscore.</simpara>
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -816,7 +816,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -937,7 +937,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -1009,9 +1009,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -1070,7 +1070,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1287,10 +1287,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1321,9 +1321,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1336,7 +1336,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1413,7 +1413,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1447,7 +1447,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1483,7 +1483,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1500,7 +1500,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1537,7 +1537,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1635,14 +1635,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1680,7 +1680,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1785,9 +1785,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1802,7 +1802,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1858,7 +1858,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1891,7 +1891,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1906,16 +1906,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1926,7 +1926,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1976,7 +1976,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.1.0.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.1.0.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -81,7 +81,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -106,7 +106,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -121,9 +121,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -173,7 +173,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -204,7 +204,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -212,7 +212,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -230,7 +230,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -357,7 +357,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -418,7 +418,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -427,7 +427,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -469,7 +469,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -773,7 +773,7 @@ underscore.</simpara>
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -816,7 +816,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -937,7 +937,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -1009,9 +1009,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -1070,7 +1070,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1287,10 +1287,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1321,9 +1321,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1336,7 +1336,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1413,7 +1413,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1447,7 +1447,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1483,7 +1483,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1500,7 +1500,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1537,7 +1537,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1635,14 +1635,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1680,7 +1680,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1785,9 +1785,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1802,7 +1802,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1858,7 +1858,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1891,7 +1891,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1906,16 +1906,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1926,7 +1926,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1976,7 +1976,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-aws/2.1.1.RELEASE/spring-cloud-aws.xml
+++ b/spring-cloud-aws/2.1.1.RELEASE/spring-cloud-aws.xml
@@ -29,8 +29,8 @@
 </preface>
 <chapter xml:id="_using_amazon_web_services">
 <title>Using Amazon Web Services</title>
-<simpara>Amazon provides a <link xl:href="http://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
-<link xl:href="http://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
+<simpara>Amazon provides a <link xl:href="https://aws.amazon.com/sdk-for-java/">Java SDK</link> to issue requests for the all services provided by the
+<link xl:href="https://aws.amazon.com">Amazon Web Service</link> platform. Using the SDK, application developers still have to integrate the
 SDK into their application with a considerable amount of infrastructure related code. Spring Cloud AWS provides application
 developers already integrated Spring-based modules to consume services and avoid infrastructure related code as much as possible.
 The Spring Cloud AWS module provides a module set so that application developers can arrange the dependencies based on
@@ -48,22 +48,22 @@ with the service support for the respective Spring Cloud AWS services.</simpara>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Core</emphasis> is the core module of Spring Cloud AWS providing basic services for security and configuration
 setup. Developers will not use this module directly but rather through other modules. The core module provides support for
-cloud based environment configurations providing direct access to the instance based <link xl:href="http://aws.amazon.com/ec2/">EC2</link>
-metadata and the overall application stack specific <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
+cloud based environment configurations providing direct access to the instance based <link xl:href="https://aws.amazon.com/ec2/">EC2</link>
+metadata and the overall application stack specific <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link> metadata.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="http://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
-resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="http://aws.amazon.com/ses/">Simple E-Mail Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS Context</emphasis> delivers access to the <link xl:href="https://aws.amazon.com/s3/">Simple Storage Service</link> via the Spring
+resource loader abstraction. Moreover developers can send e-mails using the <link xl:href="https://aws.amazon.com/ses/">Simple E-Mail Service</link>
 and the Spring mail abstraction. Further the developers can introduce declarative caching using the Spring caching support
-and the <link xl:href="http://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
+and the <link xl:href="https://aws.amazon.com/elasticache/">ElastiCache</link> caching service.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="http://aws.amazon.com/rds/">Relational Database Service</link>
+<simpara><emphasis role="strong">Spring Cloud AWS JDBC</emphasis> provides automatic datasource lookup and configuration for the <link xl:href="https://aws.amazon.com/rds/">Relational Database Service</link>
 which can be used with JDBC or any other support data access technology by Spring.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="http://aws.amazon.com/sqs/">Simple Queueing Service</link> for
-point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="http://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
+<simpara><emphasis role="strong">Spring Cloud AWS Messaging</emphasis> enables developers to receive and send messages with the <link xl:href="https://aws.amazon.com/sqs/">Simple Queueing Service</link> for
+point-to-point communication. Publish-subscribe messaging is supported with the integration of the <link xl:href="https://aws.amazon.com/sns/">Simple Notification Service</link>.</simpara>
 </listitem>
 <listitem>
 <simpara><emphasis role="strong">Spring Cloud AWS Parameter Store Configuration</emphasis> enables Spring Cloud applications to use the <link xl:href="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html">AWS Parameter Store</link>
@@ -81,7 +81,7 @@ as a Bootstrap Property Source, comparable to the support provided for the Sprin
 The next chapters describe the dependency management and also the basic configuration for the Spring AWS Cloud project.</simpara>
 <section xml:id="_spring_cloud_aws_maven_dependency_management">
 <title>Spring Cloud AWS maven dependency management</title>
-<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="http://maven.apache.org">Maven</link> with a direct configuration
+<simpara>Spring Cloud AWS module dependencies can be used directly in <link xl:href="https://maven.apache.org">Maven</link> with a direct configuration
 of the particular module. The Spring Cloud AWS module includes all transitive dependencies for the Spring modules and
 also the Amazon SDK that are needed to operate the modules. The general dependency configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependencies&gt;
@@ -98,7 +98,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.release&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/release/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/release/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -106,7 +106,7 @@ developer snapshots), you need to specify the repository location in your Maven 
 <programlisting language="xml" linenumbering="unnumbered">&lt;repositories&gt;
     &lt;repository&gt;
         &lt;id&gt;io.spring.repo.maven.milestone&lt;/id&gt;
-        &lt;url&gt;http://repo.spring.io/milestone/&lt;/url&gt;
+        &lt;url&gt;https://repo.spring.io/milestone/&lt;/url&gt;
         &lt;snapshots&gt;&lt;enabled&gt;false&lt;/enabled&gt;&lt;/snapshots&gt;
     &lt;/repository&gt;
 &lt;/repositories&gt;</programlisting>
@@ -121,9 +121,9 @@ use of the modules. A typical XML configuration to use Spring Cloud AWS is outli
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cloud/aws/context
-        http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+        https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
            &lt;aws-context:context-region region="..."/&gt;
 &lt;/beans&gt;</programlisting>
@@ -173,7 +173,7 @@ and not be checked in into the source management system.</simpara>
 </section>
 <section xml:id="_instance_profile_configuration">
 <title>Instance profile configuration</title>
-<simpara>An <link xl:href="http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
+<simpara>An <link xl:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html">instance profile configuration</link> allows to assign
 a profile that is authorized by a role while starting an EC2 instance. All calls made from the EC2 instance are then authenticated
 with the instance profile specific user role. Therefore there is no dedicated access-key and secret-key needed in the configuration.
 The configuration for the instance profile in Spring Cloud AWS looks like this:</simpara>
@@ -204,7 +204,7 @@ errors if the properties are not configured at all.</simpara>
 <simpara>The Parameter Store and Secrets Manager Configuration support uses a bootstrap context to configure a default <literal>AWSSimpleSystemsManagement</literal>
 client, which uses a <literal>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</literal> and <literal>com.amazonaws.regions.DefaultAwsRegionProviderChain</literal>.
 If you want to override this, then you need to
-<link xl:href="http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
+<link xl:href="https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html#_customizing_the_bootstrap_configuration">define your own Spring Cloud bootstrap configuration class</link>
 with a bean of type <literal>AWSSimpleSystemsManagement</literal> that&#8217;s configured to use your chosen credentials and/or region provider.
 Because this context is created when your Spring Cloud Bootstrap context is created, you can&#8217;t simply override the bean
 in a regular <literal>@Configuration</literal> class.</simpara>
@@ -212,7 +212,7 @@ in a regular <literal>@Configuration</literal> class.</simpara>
 </section>
 <section xml:id="_region_configuration">
 <title>Region configuration</title>
-<simpara>Amazon Web services are available in different <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
+<simpara>Amazon Web services are available in different <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html">regions</link>. Based
 on the custom requirements, the user can host the application on different Amazon regions. The <literal>spring-cloud-aws-context</literal>
 module provides a way to define the region for the entire application context.</simpara>
 <section xml:id="_explicit_region_configuration">
@@ -230,7 +230,7 @@ be reconfigured with property files or system properties.</simpara>
 <section xml:id="_automatic_region_configuration">
 <title>Automatic region configuration</title>
 <simpara>If the application context is started inside an EC2 instance, then the region can automatically be fetched from the
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata</link> and therefore must
 not be configured statically. The configuration will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans ...&gt;
   &lt;aws-context:context-region auto-detect="true" /&gt;
@@ -357,7 +357,7 @@ Amazon cloud environment. Spring Cloud AWS provides a support to retrieve and us
 application context using common Spring mechanisms like property placeholder or the Spring expression language.</simpara>
 <section xml:id="_retrieving_instance_metadata">
 <title>Retrieving instance metadata</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">Instance metadata</link> are available inside an
 EC2 environment. The metadata can be queried using a special HTTP address that provides the instance metadata. Spring Cloud
 AWS enables application to access this metadata directly in expression or property placeholder without the need to call
 an external HTTP service.</simpara>
@@ -418,7 +418,7 @@ public class ApplicationInfoBean {
     private String serviceDomain;
 }</programlisting>
 <note>
-<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
+<simpara>Every instance metadata can be accessed by the key available in the <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">instance metadata service</link>
 Nested properties can be accessed by separating the properties with a slash ('/').</simpara>
 </note>
 </section>
@@ -427,7 +427,7 @@ Nested properties can be accessed by separating the properties with a slash ('/'
 <simpara>Besides the default instance metadata it is also possible to configure user data on each instance. This user data is retrieved and
 parsed by Spring Cloud AWS. The user data can be defined while starting an EC2 instance with the application. Spring Cloud AWS
 expects the format <literal>&lt;key&gt;:&lt;value&gt;;&lt;key&gt;:&lt;value&gt;</literal> inside the user data so that it can parse the string and extract the key value pairs.</simpara>
-<simpara>The user data can be configured using either the management console shown below or a <link xl:href="http://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
+<simpara>The user data can be configured using either the management console shown below or a <link xl:href="https://aws.amazon.com/cloudformation/aws-cloudformation-templates/">CloudFormation template</link>.</simpara>
 <informalfigure>
 <mediaobject>
 <imageobject>
@@ -469,7 +469,7 @@ of Amazon Web services and used in different services. Spring Cloud AWS supports
 services. Compared to user data, user tags can be updated during runtime, there is no need to stop and restart
 the instance.</simpara>
 <tip>
-<simpara><link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
+<simpara><link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html">User data</link> can also be used to execute scripts
 on instance startup. Therefore it is useful to leverage instance tags for user configuration and user data to execute scripts
 on instance startup.</simpara>
 </tip>
@@ -773,7 +773,7 @@ underscore.</simpara>
 <chapter xml:id="_managing_cloud_environments">
 <title>Managing cloud environments</title>
 <simpara>Managing environments manually with the management console does not scale and can become error-prone with the increasing
-complexity of the infrastructure. Amazon Web services offers a <link xl:href="http://aws.amazon.com/cloudformation/">CloudFormation</link>
+complexity of the infrastructure. Amazon Web services offers a <link xl:href="https://aws.amazon.com/cloudformation/">CloudFormation</link>
 service that allows to define stack configuration templates and bootstrap the whole infrastructure with the services.
 In order to allow multiple stacks in parallel, each resource in the stack receives a unique physical name that contains
 some arbitrary generated name. In order to interact with the stack resources in a unified way Spring Cloud AWS allows
@@ -816,7 +816,7 @@ the database.</simpara>
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
   &lt;aws-context:context-credentials&gt;
   	...
@@ -937,7 +937,7 @@ with a special setup. The client itself can be configured using the <literal>ama
 </chapter>
 <chapter xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud AWS provides <link xl:href="http://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="http://aws.amazon.com/sqs/">Amazon SNS</link> integration
+<simpara>Spring Cloud AWS provides <link xl:href="https://aws.amazon.com/sqs/">Amazon SQS</link> and <link xl:href="https://aws.amazon.com/sqs/">Amazon SNS</link> integration
 that simplifies the publication and consumption of messages over SQS or SNS. While SQS fully relies on the messaging API
 introduced with Spring 4.0, SNS only partially implements it as the receiving part must be handled differently for
 push notifications.</simpara>
@@ -1009,9 +1009,9 @@ resource name resolution).</simpara>
 	xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
 	xmlns="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/cloud/aws/context
-		http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
+		https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd
 		http://www.springframework.org/schema/cloud/aws/messaging
 	   	http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging"&gt;
 
@@ -1070,7 +1070,7 @@ annotation. The incoming messages are converted to the target type and then the 
 <simpara>In addition to the payload, headers can be injected in the listener methods with the <literal>@Header</literal> or <literal>@Headers</literal>
 annotations. <literal>@Header</literal> is used to inject a specific header value while <literal>@Headers</literal> injects a <literal>Map&lt;String, String&gt;</literal>
 containing all headers.</simpara>
-<simpara>Only the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
+<simpara>Only the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html">standard
 message attributes</link> sent with an SQS message are supported. Custom attributes are currently not supported.</simpara>
 <simpara>In addition to the provided argument resolvers, custom ones can be registered on the
 <literal>aws-messaging:annotation-driven-queue-listener</literal> element using the <literal>aws-messaging:argument-resolvers</literal> attribute (see example below).</simpara>
@@ -1287,10 +1287,10 @@ configuration or code changes inside the application.</simpara>
 Reducing database round trips can significantly reduce the requirements for the database instance. The Spring Framework
 provides, since version 3.1, a unified Cache abstraction to allow declarative caching in applications analogous to the
 declarative transactions.</simpara>
-<simpara>Spring Cloud AWS integrates the <link xl:href="http://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
+<simpara>Spring Cloud AWS integrates the <link xl:href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</link> service into the Spring unified
 caching abstraction providing a cache manager based on the memcached and Redis protocols. The caching support for Spring
 Cloud AWS provides its own memcached implementation for ElastiCache and uses
-<link xl:href="http://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
+<link xl:href="https://projects.spring.io/spring-data-redis/">Spring Data Redis</link> for Redis caches.</simpara>
 <section xml:id="_configuring_dependencies_for_redis_caches">
 <title>Configuring dependencies for Redis caches</title>
 <simpara>Spring Cloud AWS delivers its own implementation of a memcached cache, therefore no other dependencies are needed. For Redis
@@ -1321,9 +1321,9 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/cache
-	   	http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
+	   	https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd
 	   	http://www.springframework.org/schema/cache
-	   	http://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
+	   	https://www.springframework.org/schema/cache/spring-cache.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 		...
@@ -1336,7 +1336,7 @@ configuration to enable declarative, annotation-based caching.</simpara>
 	&lt;cache:annotation-driven /&gt;
 &lt;/beans&gt;</programlisting>
 <simpara>The configuration above configures a <literal>cache-manager</literal> with one cache with the name <literal>CacheCluster</literal> that represents an
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html">ElasticCache cluster</link>.</simpara>
 <section xml:id="_mixing_caches">
 <title>Mixing caches</title>
 <simpara>Applications may have the need for multiple caches that are maintained by one central cache cluster. The Spring Cloud
@@ -1413,7 +1413,7 @@ public class ExpensiveService {
 <simpara>There are different memcached client implementations available for Java, the most prominent ones are
 <link xl:href="https://github.com/couchbase/spymemcached">Spymemcached</link> and <link xl:href="https://github.com/killme2008/xmemcached">XMemcached</link>.
 Amazon AWS supports a dynamic configuration and delivers an enhanced memcached client based on Spymemcached to support the
-<link xl:href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
+<link xl:href="https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html">auto-discovery</link> of new nodes based on
 a central configuration endpoint.</simpara>
 <simpara>Spring Cloud AWS relies on the Amazon ElastiCache Client implementation and therefore has a dependency on that.</simpara>
 </section>
@@ -1447,7 +1447,7 @@ without any configuration change inside the application.</simpara>
 <title>Data Access with JDBC</title>
 <simpara>Spring has a broad support of data access technologies built on top of JDBC like <literal>JdbcTemplate</literal> and dedicated ORM (JPA,
 Hibernate support). Spring Cloud AWS enables application developers to re-use their JDBC technology of choice and access the
-<link xl:href="http://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
+<link xl:href="https://aws.amazon.com/rds/">Amazon Relational Database Service</link> with a declarative configuration. The main support provided by Spring
 Cloud AWS for JDBC data access are:</simpara>
 <itemizedlist>
 <listitem>
@@ -1483,7 +1483,7 @@ to configure the data source with the minimum attributes as shown in the example
 	   xmlns:jdbc="http://www.springframework.org/schema/cloud/aws/jdbc"
 	   xmlns="http://www.springframework.org/schema/beans"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/jdbc
-	   http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd"&gt;
 
  &lt;aws-context:context-credentials&gt;
   ...
@@ -1500,7 +1500,7 @@ to configure the data source with the minimum attributes as shown in the example
 that points to a valid Amazon RDS database instance. The master user password for the master user. If there is another
 user to be used (which is recommended) then the <literal>username</literal> attribute can be set.</simpara>
 <simpara>With this configuration Spring Cloud AWS fetches all the necessary metadata and creates a
-<link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
+<link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC pool</link> with the default properties. The data source
 can be later injected into any Spring Bean as shown below:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Service
 public class SimpleDatabaseService implements DatabaseService {
@@ -1537,7 +1537,7 @@ with custom pool properties.</simpara>
  &lt;/jdbc:data-source&gt;
 
 &lt;/beans&gt;</programlisting>
-<simpara>A full list of all configuration attributes with their value is available <link xl:href="http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
+<simpara>A full list of all configuration attributes with their value is available <link xl:href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">here</link>.</simpara>
 </section>
 </section>
 <section xml:id="_configuring_data_source_with_java_config">
@@ -1635,14 +1635,14 @@ outlines all properties for a data source using <literal>test</literal> as the i
 </section>
 <section xml:id="_read_replica_configuration">
 <title>Read-replica configuration</title>
-<simpara>Amazon RDS allows to use <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
+<simpara>Amazon RDS allows to use <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html">MySQL read-replica</link>
 instances to increase the overall throughput of the database by offloading read data access to one or more read-replica
 slaves while maintaining the data in one master database.</simpara>
 <simpara>Spring Cloud AWS supports the use of read-replicas in combination with Spring read-only transactions. If the read-replica
 support is enabled, any read-only transaction will be routed to a read-replica instance while using the master database
 for write operations.</simpara>
 <caution>
-<simpara>Using read-replica instances does not guarantee strict <link xl:href="http://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
+<simpara>Using read-replica instances does not guarantee strict <link xl:href="https://en.wikipedia.org/wiki/ACID">ACID</link> semantics for the database
 access and should be used with care. This is due to the fact that the read-replica might be behind and a write might not
 be immediately visible to the read transaction. Therefore it is recommended to use read-replica instances only for transactions that read
 data which is not changed very often and where outdated data can be handled by the application.</simpara>
@@ -1680,7 +1680,7 @@ public class SimpleDatabaseService {
 </section>
 <section xml:id="_failover_support">
 <title>Failover support</title>
-<simpara>Amazon RDS supports a <link xl:href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
+<simpara>Amazon RDS supports a <link xl:href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html">Multi-AZ</link> fail-over if
 one availability zone is not available due to an outage or failure of the primary instance. The replication is synchronous
 (compared to the read-replicas) and provides continuous service. Spring Cloud AWS supports a Multi-AZ failover with a retry
 mechanism to recover transactions that fail during a Multi-AZ failover.</simpara>
@@ -1785,9 +1785,9 @@ database is configured using CloudFormation.</simpara>
 </chapter>
 <chapter xml:id="_sending_mails">
 <title>Sending mails</title>
-<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="http://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
+<simpara>Spring has a built-in support to send e-mails based on the <link xl:href="https://www.oracle.com/technetwork/java/javamail/index.html">Java Mail API</link>
 to avoid any static method calls while using the Java Mail API and thus supporting the testability of an application.
-Spring Cloud AWS supports the <link xl:href="http://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
+Spring Cloud AWS supports the <link xl:href="https://aws.amazon.com/de/ses/">Amazon SES</link> as an implementation of the Spring Mail abstraction.</simpara>
 <simpara>As a result Spring Cloud AWS users can decide to use the Spring Cloud AWS implementation of the Amazon SES service or
 use the standard Java Mail API based implementation that sends e-mails via SMTP to Amazon SES.</simpara>
 <tip>
@@ -1802,7 +1802,7 @@ client to be used. The default mail sender works without a Java Mail dependency 
 attachments as simple mail messages. A configuration with the necessary elements will look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:aws-mail="http://www.springframework.org/schema/cloud/aws/mail"
    xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/mail
-      http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
+      https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
 	  ..
@@ -1858,7 +1858,7 @@ which is shown below.</simpara>
 &lt;/dependency&gt;</programlisting>
 <note>
 <simpara>Even though there is a dependency to the Java Mail API there is still the Amazon SES API used underneath to send mail
-messages. There is no <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
+messages. There is no <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html">SMTP setup</link> required
 on the Amazon AWS side.</simpara>
 </note>
 <simpara>Sending the mail requires the application developer to use the <literal>JavaMailSender</literal> to send an e-mail as shown in the example
@@ -1891,7 +1891,7 @@ below.</simpara>
 </section>
 <section xml:id="_configuring_regions">
 <title>Configuring regions</title>
-<simpara>Amazon SES is not available in all <link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
+<simpara>Amazon SES is not available in all <link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">regions</link> of the
 Amazon Web Services cloud. Therefore an application hosted and operated in a region that does not support the mail
 service will produce an error while using the mail service. Therefore the region must be overridden for the mail
 sender configuration. The example below shows a typical combination of a region (EU-CENTRAL-1) that does not provide
@@ -1906,16 +1906,16 @@ an SES service where the client is overridden to use a valid region (EU-WEST-1).
 <section xml:id="_authenticating_e_mails">
 <title>Authenticating e-mails</title>
 <simpara>To avoid any spam attacks on the Amazon SES mail service, applications without production access must
-<link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
+<link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">verify</link> each
 e-mail receiver otherwise the mail sender will throw a <literal>com.amazonaws.services.simpleemail.model.MessageRejectedException</literal>.</simpara>
-<simpara><link xl:href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
+<simpara><link xl:href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Production access</link> can be requested
 and will disable the need for mail address verification.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_resource_handling">
 <title>Resource handling</title>
 <simpara>The Spring Framework provides a <literal>org.springframework.core.io.ResourceLoader</literal> abstraction to load files from the filesystem,
-servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="http://aws.amazon.com/s3/">Amazon S3</link> service
+servlet context and the classpath. Spring Cloud AWS adds support for the <link xl:href="https://aws.amazon.com/s3/">Amazon S3</link> service
 to load and write resources with the resource loader and the <literal>s3</literal> protocol.</simpara>
 <simpara>The resource loader is part of the context module, therefore no additional dependencies are necessary to use the resource
 handling support.</simpara>
@@ -1926,7 +1926,7 @@ The configuration consists of one element for the whole application context that
 <programlisting language="xml" linenumbering="unnumbered">&lt;beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aws-context="http://www.springframework.org/schema/cloud/aws/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/cloud/aws/context
-	   http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
+	   https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd"&gt;
 
 	&lt;aws-context:context-credentials&gt;
     		...
@@ -1976,7 +1976,7 @@ using the <literal>WritableResource</literal> interface. The next example demons
 }</programlisting>
 <section xml:id="_uploading_multi_part_files">
 <title>Uploading multi-part files</title>
-<simpara>Amazon S3 supports <link xl:href="http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
+<simpara>Amazon S3 supports <link xl:href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">multi-part uploads</link> to
 increase the general throughput while uploading. Spring Cloud AWS by default only uses one thread to upload the files and
 therefore does not provide parallel upload support. Users can configure a custom <literal>org.springframework.core.task.TaskExecutor</literal>
 for the resource loader. The resource loader will queue multiple threads at the same time to use parallel multi-part uploads.</simpara>

--- a/spring-cloud-build/1.3.10.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/1.3.10.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/1.3.6.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/1.3.6.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/1.3.7.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/1.3.7.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/2.0.0.M6/spring-cloud-build.xml
+++ b/spring-cloud-build/2.0.0.M6/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/2.0.3.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/2.0.3.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/2.0.4.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/2.0.4.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/2.1.1.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/2.1.1.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-build/2.1.3.RELEASE/spring-cloud-build.xml
+++ b/spring-cloud-build/2.1.3.RELEASE/spring-cloud-build.xml
@@ -64,7 +64,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -91,7 +91,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -184,7 +184,7 @@ message (where XXXX is the issue number).</simpara>
 <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
 &lt;suppressions&gt;
 	&lt;suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/&gt;
 	&lt;suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/&gt;

--- a/spring-cloud-cli/1.4.0.RELEASE/spring-cloud-cli.xml
+++ b/spring-cloud-cli/1.4.0.RELEASE/spring-cloud-cli.xml
@@ -8,7 +8,7 @@
 </info>
 <preface>
 <title></title>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do

--- a/spring-cloud-cli/2.0.0.RELEASE/spring-cloud-cli.xml
+++ b/spring-cloud-cli/2.0.0.RELEASE/spring-cloud-cli.xml
@@ -8,7 +8,7 @@
 </info>
 <preface>
 <title></title>
-<simpara>Spring Boot CLI provides <link xl:href="http://projects.spring.io/spring-boot">Spring
+<simpara>Spring Boot CLI provides <link xl:href="https://projects.spring.io/spring-boot">Spring
 Boot</link> command line features for <link xl:href="https://github.com/spring-cloud">Spring
 Cloud</link>. You can write Groovy scripts to run Spring Cloud component
 applications (e.g. <literal>@EnableEurekaServer</literal>). You can also easily do

--- a/spring-cloud-cloudfoundry/1.1.1.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/1.1.1.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/1.1.2.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/1.1.2.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.0.0.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.0.0.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.0.1.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.0.1.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.1.0.M1/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.1.0.M1/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.1.0.RC1/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.1.0.RC1/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.1.0.RC2/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.1.0.RC2/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.1.0.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.1.0.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-cloudfoundry/2.1.1.RELEASE/spring-cloud-cloudfoundry.xml
+++ b/spring-cloud-cloudfoundry/2.1.1.RELEASE/spring-cloud-cloudfoundry.xml
@@ -65,7 +65,7 @@ are configured, they default per the user&#8217;s profile in Cloud Foundry.</sim
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 <simpara>This project provides automatic binding from CloudFoundry service
 credentials to the Spring Boot features. If you have a CloudFoundry

--- a/spring-cloud-commons/1.2.4.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.2.4.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 </section>
 <section xml:id="_serviceregistry">
@@ -447,7 +447,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.2.5.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.2.5.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 </section>
 <section xml:id="_serviceregistry">
@@ -447,7 +447,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.0.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.0.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -470,7 +470,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.1.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.1.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -501,7 +501,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.2.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.2.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -501,7 +501,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.3.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.3.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -298,13 +298,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -333,7 +333,7 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -501,7 +501,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.4.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.4.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -305,13 +305,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -344,7 +344,7 @@ will also be disabled since they are just a special case of <literal>/restart</l
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -526,7 +526,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/1.3.5.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/1.3.5.RELEASE/spring-cloud-commons.xml
@@ -8,18 +8,18 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development. A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Apps</link> in which development practices are aligned with delivery and operations goals, for instance by using declarative programming and management and monitoring. Spring Cloud facilitates these styles of development in a number of specific ways and the starting point is a set of features that all components in a distributed system either need or need easy access to when required.</simpara>
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, which we build on in Spring Cloud. Some more are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons. Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (eg. Spring Cloud Netflix vs. Spring Cloud Consul).</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -305,13 +305,13 @@ the full strength JCE extensions in your JVM.</simpara>
 <simpara>If you are getting an exception due to "Illegal key size" and you are using Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).</simpara>
@@ -344,7 +344,7 @@ will also be disabled since they are just a special case of <literal>/restart</l
 <simpara>Patterns such as service discovery, load balancing and circuit breakers lend themselves to a common abstraction layer that can be consumed by all Spring Cloud clients, independent of the implementation (e.g. discovery via Eureka or Consul).</simpara>
 <section xml:id="__enablediscoveryclient">
 <title>@EnableDiscoveryClient</title>
-<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+<simpara>Commons provides the <literal>@EnableDiscoveryClient</literal> annotation. This looks for implementations of the <literal>DiscoveryClient</literal> interface via <literal>META-INF/spring.factories</literal>. Implementations of Discovery Client will add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key. Examples of <literal>DiscoveryClient</literal> implementations: are <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link> and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> will auto-register the local Spring Boot server with the remote discovery server. This can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
 <simpara>The use of <literal>@EnableDiscoveryClient</literal> is no longer required.  It is enough to just have a <literal>DiscoveryClient</literal> implementation
@@ -526,7 +526,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <tip>

--- a/spring-cloud-commons/2.0.0.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.0.0.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -218,13 +218,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -260,7 +260,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -477,7 +477,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.0.1.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.0.1.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -222,13 +222,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,7 +264,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -481,7 +481,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.0.2.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.0.2.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -222,13 +222,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,7 +264,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -491,7 +491,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.0.3.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.0.3.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -222,13 +222,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,7 +264,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -491,7 +491,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.0.M1/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.0.M1/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -222,13 +222,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -264,7 +264,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -493,7 +493,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.0.M2/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.0.M2/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -227,13 +227,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,7 +269,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -508,7 +508,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.0.RC1/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.0.RC1/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -227,13 +227,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,7 +269,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -508,7 +508,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.0.RC2/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.0.RC2/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -227,13 +227,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,7 +269,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -508,7 +508,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.0.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.0.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -227,13 +227,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,7 +269,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -508,7 +508,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-commons/2.1.1.RELEASE/spring-cloud-commons.xml
+++ b/spring-cloud-commons/2.1.1.RELEASE/spring-cloud-commons.xml
@@ -8,23 +8,23 @@
 </info>
 <preface>
 <title></title>
-<simpara><link xl:href="http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building <link xl:href="http://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
+<simpara><link xl:href="https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook">Cloud Native</link> is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building <link xl:href="https://12factor.net/">12-factor Applications</link>, in which development practices are aligned with delivery and operations goals&#8201;&#8212;&#8201;for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.</simpara>
-<simpara>Many of those features are covered by <link xl:href="http://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+<simpara>Many of those features are covered by <link xl:href="https://projects.spring.io/spring-boot">Spring Boot</link>, on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the <literal>ApplicationContext</literal> of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).</simpara>
 <simpara>If you get an exception due to "Illegal key size" and you use Sun&#8217;s JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -227,13 +227,13 @@ To use the encryption features in an application, you need to include Spring Sec
 See the following links for more information:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">Java 6 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">Java 7 JCE</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
+<simpara><link xl:href="https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html">Java 8 JCE</link></simpara>
 </listitem>
 </itemizedlist>
 <simpara>Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.</simpara>
@@ -269,7 +269,7 @@ will also be disabled since they are just a special case of <literal>/actuator/r
 <simpara>Spring Cloud Commons provides the <literal>@EnableDiscoveryClient</literal> annotation.
 This looks for implementations of the <literal>DiscoveryClient</literal> interface with <literal>META-INF/spring.factories</literal>.
 Implementations of the Discovery Client add a configuration class to <literal>spring.factories</literal> under the <literal>org.springframework.cloud.client.discovery.EnableDiscoveryClient</literal> key.
-Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="http://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="http://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
+Examples of <literal>DiscoveryClient</literal> implementations include <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix Eureka</link>, <link xl:href="https://cloud.spring.io/spring-cloud-consul/">Spring Cloud Consul Discovery</link>, and <link xl:href="https://cloud.spring.io/spring-cloud-zookeeper/">Spring Cloud Zookeeper Discovery</link>.</simpara>
 <simpara>By default, implementations of <literal>DiscoveryClient</literal> auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting <literal>autoRegister=false</literal> in <literal>@EnableDiscoveryClient</literal>.</simpara>
 <note>
@@ -508,7 +508,7 @@ public class MyClass {
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }</programlisting>
 <important>

--- a/spring-cloud-config/1.3.3.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.3.3.RELEASE/spring-cloud-config.xml
@@ -386,14 +386,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -436,20 +436,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -577,15 +577,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -594,7 +594,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.3.4.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.3.4.RELEASE/spring-cloud-config.xml
@@ -386,14 +386,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -436,20 +436,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -577,15 +577,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -594,7 +594,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.0.RC1/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.0.RC1/spring-cloud-config.xml
@@ -386,14 +386,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -436,20 +436,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -585,15 +585,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -602,7 +602,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.0.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.0.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.1.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.1.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.2.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.2.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.3.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.3.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -636,7 +636,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.4.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.4.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -605,15 +605,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -644,7 +644,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/1.4.5.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/1.4.5.RELEASE/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -605,15 +605,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -644,7 +644,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M3/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M3/spring-cloud-config.xml
@@ -386,14 +386,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -436,20 +436,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -585,15 +585,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -602,7 +602,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M4/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M4/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M5/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M5/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M6/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M6/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M7/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M7/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M8/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M8/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/spring-cloud-config/2.0.0.M9/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.M9/spring-cloud-config.xml
@@ -322,14 +322,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -363,14 +363,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -501,15 +501,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -543,7 +543,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.0.RC1/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.RC1/spring-cloud-config.xml
@@ -322,14 +322,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -363,14 +363,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -501,15 +501,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -542,7 +542,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.0.RC2/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.RC2/spring-cloud-config.xml
@@ -322,14 +322,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -363,14 +363,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -501,15 +501,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -542,7 +542,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.0.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.0.RELEASE/spring-cloud-config.xml
@@ -343,14 +343,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -384,14 +384,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -522,15 +522,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -564,7 +564,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.1.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.1.RELEASE/spring-cloud-config.xml
@@ -343,14 +343,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -384,14 +384,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -522,15 +522,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -564,7 +564,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.2.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.2.RELEASE/spring-cloud-config.xml
@@ -343,14 +343,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -384,14 +384,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -522,15 +522,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -572,7 +572,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.0.3.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.0.3.RELEASE/spring-cloud-config.xml
@@ -343,14 +343,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -384,14 +384,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -522,15 +522,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -572,7 +572,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.M1/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.M1/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -569,7 +569,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.M2/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.M2/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -569,7 +569,7 @@ Example:</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.M3/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.M3/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -577,7 +577,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.RC1/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.RC1/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -577,7 +577,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.RC2/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.RC2/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -577,7 +577,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.RC3/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.RC3/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -577,7 +577,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.0.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.0.RELEASE/spring-cloud-config.xml
@@ -348,14 +348,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -389,14 +389,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -527,15 +527,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -577,7 +577,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-config/2.1.1.RELEASE/spring-cloud-config.xml
+++ b/spring-cloud-config/2.1.1.RELEASE/spring-cloud-config.xml
@@ -349,14 +349,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -390,14 +390,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -528,15 +528,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -578,7 +578,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/spring-cloud-consul/1.2.3.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.2.3.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -142,7 +142,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded.  Watching the key value store (which Consul supports) is not currently possible, but will be a future addition to this project.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -254,13 +254,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.0.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.0.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.1.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.1.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.2.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.2.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.3.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.3.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.4.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.4.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/1.3.5.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/1.3.5.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -120,7 +120,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -165,7 +165,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -277,13 +277,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.0.0.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.0.0.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -121,7 +121,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -173,7 +173,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -286,13 +286,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.0.1.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.0.1.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -121,7 +121,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -173,7 +173,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -286,13 +286,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.0.2.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.0.2.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -121,7 +121,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -173,7 +173,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -286,13 +286,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.M1/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.M1/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -150,7 +150,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -202,7 +202,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -315,13 +315,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.M2/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.M2/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -150,7 +150,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -202,7 +202,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -315,13 +315,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.RC1/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.RC1/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -150,7 +150,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -202,7 +202,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -315,13 +315,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.RC2/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.RC2/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -150,7 +150,7 @@ public class Application {
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -202,7 +202,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -315,13 +315,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.RC3/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.RC3/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -222,7 +222,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -274,7 +274,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -387,13 +387,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.0.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.0.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -222,7 +222,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -274,7 +274,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -387,13 +387,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-consul/2.1.1.RELEASE/spring-cloud-consul.xml
+++ b/spring-cloud-consul/2.1.1.RELEASE/spring-cloud-consul.xml
@@ -32,7 +32,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle.  Consul provides Service Discovery services via an <link xl:href="https://www.consul.io/docs/agent/http.html">HTTP API</link> and <link xl:href="https://www.consul.io/docs/agent/dns.html">DNS</link>.  Spring Cloud Consul leverages the HTTP API for service registration and discovery.  This does not prevent non-Spring Cloud applications from leveraging the DNS interface.  Consul Agents servers are run in a <link xl:href="https://www.consul.io/docs/internals/architecture.html">cluster</link> that communicates via a <link xl:href="https://www.consul.io/docs/internals/gossip.html">gossip protocol</link> and uses the <link xl:href="https://www.consul.io/docs/internals/consensus.html">Raft consensus protocol</link>.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
-<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To activate Consul Service Discovery use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-discovery</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_consul">
 <title>Registering with Consul</title>
@@ -222,7 +222,7 @@ spring.cloud.consul.discovery.management-tags</screen>
 <section xml:id="_using_ribbon">
 <title>Using Ribbon</title>
 <simpara>Spring Cloud has support for <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-feign">Feign</link> (a REST client builder) and also <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/blob/master/docs/src/main/asciidoc/spring-cloud-netflix.adoc#spring-cloud-ribbon">Spring <literal>RestTemplate</literal></link>
-for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
+for looking up services using the logical service names/ids instead of physical URLs. Both Feign and the discovery-aware RestTemplate utilize <link xl:href="https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html#spring-cloud-ribbon">Ribbon</link> for client-side load balancing.</simpara>
 <simpara>If you want to access service STORES using the RestTemplate simply declare:</simpara>
 <screen>@LoadBalanced
 @Bean
@@ -274,7 +274,7 @@ config/application/</screen>
 <simpara>Configuration is currently read on startup of the application.  Sending a HTTP POST to <literal>/refresh</literal> will cause the configuration to be reloaded. <xref linkend="spring-cloud-consul-config-watch"/> will also automatically detect changes and reload the application context.</simpara>
 <section xml:id="_how_to_activate_2">
 <title>How to activate</title>
-<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with Consul Configuration use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-config</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>This will enable auto-configuration that will setup Spring Cloud Consul Config.</simpara>
 </section>
 <section xml:id="_customizing">
@@ -387,13 +387,13 @@ Retry has a <literal>RetryInterceptorBuilder</literal> that makes it easy to cre
 <title>Spring Cloud Bus with Consul</title>
 <section xml:id="_how_to_activate_3">
 <title>How to activate</title>
-<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To get started with the Consul Bus use the starter with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-starter-consul-bus</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>See the <link xl:href="https://cloud.spring.io/spring-cloud-bus/">Spring Cloud Bus</link> documentation for the available actuator endpoints and howto send custom messages.</simpara>
 </section>
 </chapter>
 <chapter xml:id="spring-cloud-consul-hystrix">
 <title>Circuit Breaker with Hystrix</title>
-<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="http://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
+<simpara>Applications can use the Hystrix Circuit Breaker provided by the Spring Cloud Netflix project by including this starter in the projects pom.xml: <literal>spring-cloud-starter-hystrix</literal>.  Hystrix doesn&#8217;t depend on the Netflix Discovery Client. The <literal>@EnableHystrix</literal> annotation should be placed on a configuration class (usually the main class). Then methods can be annotated with <literal>@HystrixCommand</literal> to be protected by a circuit breaker. See <link xl:href="https://projects.spring.io/spring-cloud/spring-cloud.html#_circuit_breaker_hystrix_clients">the documentation</link> for more details.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-consul-turbine">
 <title>Hystrix metrics aggregation with Turbine and Consul</title>

--- a/spring-cloud-contract/1.0.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.0.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.0.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.0.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.0.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.0.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.0.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.0.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.0.RC1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.0.RC1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.4.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.4.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.4.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.1.4.RELEASE/spring-cloud-contract.xml
@@ -338,9 +338,9 @@ all the contract are present in the producer&#8217;s repository</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -692,7 +692,7 @@ You can switch off the value of the <literal>workOffline</literal> parameter in 
 example of achieving the same by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>And that&#8217;s it!</simpara>
 </section>
 </section>
@@ -715,7 +715,7 @@ is under constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -743,7 +743,7 @@ is under constant development.</simpara>
 <simpara>In order to use Spring Cloud Contract Verifier with WireMock you have to use Gradle or Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects you have to add separately
-the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock docs for more information</link></simpara>
+the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock docs for more information</link></simpara>
 </warning>
 </section>
 <section xml:id="_add_gradle_plugin_with_dependencies">
@@ -807,9 +807,9 @@ and will modify the imports accordingly.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -1927,9 +1927,9 @@ automatically for you.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -1972,7 +1972,7 @@ automatically for you.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -2038,7 +2038,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -2063,7 +2063,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -2579,7 +2579,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -2745,7 +2745,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -2929,7 +2929,7 @@ information about the reasons behind this change.</simpara>
 <simpara>Starting from version 1.0.4 as a version you can provide a range of versions that you would like
 the Stub Runner to take into consideration. You can read more about the <link xl:href="https://wiki.eclipse.org/Aether/New_and_Noteworthy#Version_Ranges">Aether versioning ranges here</link>.</simpara>
 </important>
-<simpara>Taken from <link xl:href="http://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
+<simpara>Taken from <link xl:href="https://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
 <blockquote>
 <simpara>This scheme accepts versions of any form, interpreting a version as a sequence of numeric and alphabetic segments. The characters '-', '_', and '.' as well as the mere
 transitions from digit to letter and vice versa delimit the version segments. Delimiters are treated as equivalent.</simpara>
@@ -3221,9 +3221,9 @@ Remember to annotate your test class with <literal>@AutoConfigureStubRunner</lit
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -3578,7 +3578,7 @@ a tiny subset of it (namely literals, method calls and closures). What&#8217;s m
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6005,7 +6005,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -6016,7 +6016,7 @@ public class WiremockForDocsMockServerApplicationTests {
 method takes a stub path resource pattern as an argument. So in this
 example the stub defined at <literal>/stubs/resource.json</literal> is loaded into the
 mock server, so if the <literal>RestTemplate</literal> is asked to visit
-<literal><link xl:href="http://example.org/">http://example.org/</link></literal> it will get the responses as declared
+<literal><link xl:href="https://example.org/">https://example.org/</link></literal> it will get the responses as declared
 there. More than one stub pattern can be specified, and each one can
 be a directory (for a recursive list of all ".json"), or a fixed
 filename (like in the example above) or an ant-style pattern. The JSON

--- a/spring-cloud-contract/1.1.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.1.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.1.5.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.1.5.RELEASE/spring-cloud-contract.xml
@@ -338,9 +338,9 @@ all the contract are present in the producer&#8217;s repository</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -692,7 +692,7 @@ You can switch off the value of the <literal>workOffline</literal> parameter in 
 example of achieving the same by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>And that&#8217;s it!</simpara>
 </section>
 </section>
@@ -715,7 +715,7 @@ is under constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -743,7 +743,7 @@ is under constant development.</simpara>
 <simpara>In order to use Spring Cloud Contract Verifier with WireMock you have to use Gradle or Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects you have to add separately
-the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock docs for more information</link></simpara>
+the <literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock docs for more information</link></simpara>
 </warning>
 </section>
 <section xml:id="_add_gradle_plugin_with_dependencies">
@@ -807,9 +807,9 @@ and will modify the imports accordingly.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -1927,9 +1927,9 @@ automatically for you.</simpara>
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -1974,7 +1974,7 @@ automatically for you.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -2040,7 +2040,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -2065,7 +2065,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -2568,7 +2568,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -2734,7 +2734,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -2918,7 +2918,7 @@ information about the reasons behind this change.</simpara>
 <simpara>Starting from version 1.0.4 as a version you can provide a range of versions that you would like
 the Stub Runner to take into consideration. You can read more about the <link xl:href="https://wiki.eclipse.org/Aether/New_and_Noteworthy#Version_Ranges">Aether versioning ranges here</link>.</simpara>
 </important>
-<simpara>Taken from <link xl:href="http://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
+<simpara>Taken from <link xl:href="https://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html">Aether Docs</link>:</simpara>
 <blockquote>
 <simpara>This scheme accepts versions of any form, interpreting a version as a sequence of numeric and alphabetic segments. The characters '-', '_', and '.' as well as the mere
 transitions from digit to letter and vice versa delimit the version segments. Delimiters are treated as equivalent.</simpara>
@@ -3210,9 +3210,9 @@ Remember to annotate your test class with <literal>@AutoConfigureStubRunner</lit
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -3571,7 +3571,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6143,7 +6143,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -6154,7 +6154,7 @@ public class WiremockForDocsMockServerApplicationTests {
 method takes a stub path resource pattern as an argument. So in this
 example the stub defined at <literal>/stubs/resource.json</literal> is loaded into the
 mock server, so if the <literal>RestTemplate</literal> is asked to visit
-<literal><link xl:href="http://example.org/">http://example.org/</link></literal> it will get the responses as declared
+<literal><link xl:href="https://example.org/">https://example.org/</link></literal> it will get the responses as declared
 there. More than one stub pattern can be specified, and each one can
 be a directory (for a recursive list of all ".json"), or a fixed
 filename (like in the example above) or an ant-style pattern. The JSON

--- a/spring-cloud-contract/1.2.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.0.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.0.RELEASE/spring-cloud-contract.xml
@@ -368,9 +368,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -800,7 +800,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -824,7 +824,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1051,7 +1051,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1163,7 +1163,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1205,7 +1205,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1239,7 +1239,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1360,7 +1360,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1427,9 +1427,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2702,9 +2702,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -2749,7 +2749,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -2815,7 +2815,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -2840,7 +2840,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3390,7 +3390,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3556,7 +3556,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4062,9 +4062,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4451,7 +4451,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7105,7 +7105,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -7115,7 +7115,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -7367,7 +7367,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.1.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.1.RELEASE/spring-cloud-contract.xml
@@ -368,9 +368,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -800,7 +800,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -824,7 +824,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1051,7 +1051,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1163,7 +1163,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1205,7 +1205,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1239,7 +1239,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1360,7 +1360,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1427,9 +1427,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2693,9 +2693,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -2740,7 +2740,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -2806,7 +2806,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -2831,7 +2831,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3381,7 +3381,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3547,7 +3547,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4053,9 +4053,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4442,7 +4442,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7096,7 +7096,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -7106,7 +7106,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -7358,7 +7358,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.2.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.2.RELEASE/spring-cloud-contract.xml
@@ -368,9 +368,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -800,7 +800,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -824,7 +824,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1051,7 +1051,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1163,7 +1163,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1205,7 +1205,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1239,7 +1239,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1361,7 +1361,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1428,9 +1428,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2694,9 +2694,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -2741,7 +2741,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -2807,7 +2807,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -2832,7 +2832,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3382,7 +3382,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3548,7 +3548,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4054,9 +4054,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4443,7 +4443,7 @@ Cloud Contract Verifier repository</link>.</simpara>
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7097,7 +7097,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -7107,7 +7107,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -7373,7 +7373,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.3.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.3.RELEASE/spring-cloud-contract.xml
@@ -430,9 +430,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -926,7 +926,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -950,7 +950,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1181,7 +1181,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1293,7 +1293,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1335,7 +1335,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1369,7 +1369,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1495,7 +1495,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1562,9 +1562,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2485,7 +2485,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -3099,9 +3099,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -3146,7 +3146,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -3212,7 +3212,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -3237,7 +3237,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3787,7 +3787,7 @@ project for more information.</simpara>
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3953,7 +3953,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4520,9 +4520,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4908,7 +4908,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6033,7 +6033,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -8207,7 +8207,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -8217,7 +8217,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -8483,7 +8483,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.4.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.4.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.4.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.4.RELEASE/spring-cloud-contract.xml
@@ -430,9 +430,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -926,7 +926,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -950,7 +950,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1181,7 +1181,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1293,7 +1293,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1335,7 +1335,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1369,7 +1369,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1494,7 +1494,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1561,9 +1561,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2452,7 +2452,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -3097,9 +3097,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -3144,7 +3144,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -3210,7 +3210,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -3235,7 +3235,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3804,7 +3804,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3970,7 +3970,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4537,9 +4537,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4925,7 +4925,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6050,7 +6050,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -8224,7 +8224,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -8234,7 +8234,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -8500,7 +8500,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.5.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.5.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.5.RELEASE/spring-cloud-contract.xml
@@ -430,9 +430,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -926,7 +926,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -950,7 +950,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1181,7 +1181,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1293,7 +1293,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1335,7 +1335,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1369,7 +1369,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1494,7 +1494,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1561,9 +1561,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2452,7 +2452,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -3097,9 +3097,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -3146,7 +3146,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -3212,7 +3212,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -3237,7 +3237,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3806,7 +3806,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3972,7 +3972,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4539,9 +4539,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4927,7 +4927,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6096,7 +6096,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -8270,7 +8270,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -8280,7 +8280,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -8546,7 +8546,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/1.2.6.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/1.2.6.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/1.2.6.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/1.2.6.RELEASE/spring-cloud-contract.xml
@@ -429,9 +429,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -924,7 +924,7 @@ the <literal>workOffline</literal> parameter in your annotation. The following c
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -948,7 +948,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1179,7 +1179,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1291,7 +1291,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1333,7 +1333,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1367,7 +1367,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -1492,7 +1492,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -1559,9 +1559,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -2450,7 +2450,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -3095,9 +3095,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -3144,7 +3144,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -3210,7 +3210,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -3235,7 +3235,7 @@ to <literal>true</literal> then Stub Runner will connect to the given server and
 It will then unpack the JAR to a temporary folder and reference those files in further
 contract processing.</simpara>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095")</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -3793,7 +3793,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -3959,7 +3959,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -4524,9 +4524,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -4912,7 +4912,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -6081,7 +6081,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -8255,7 +8255,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -8265,7 +8265,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -8531,7 +8531,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.0.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.0.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.0.0.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.0.0.RELEASE/spring-cloud-contract.xml
@@ -246,7 +246,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -493,7 +493,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -784,9 +784,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1281,7 +1281,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1305,7 +1305,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1542,7 +1542,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1654,7 +1654,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1696,7 +1696,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1730,7 +1730,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2140,7 +2140,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2424,7 +2424,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2491,9 +2491,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3505,7 +3505,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4150,9 +4150,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4199,7 +4199,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4265,7 +4265,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4299,7 +4299,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4900,7 +4900,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5066,7 +5066,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5519,9 +5519,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -5908,7 +5908,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7142,7 +7142,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9632,7 +9632,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9642,7 +9642,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -9932,7 +9932,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.0.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.0.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.0.1.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.0.1.RELEASE/spring-cloud-contract.xml
@@ -246,7 +246,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -493,7 +493,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -784,9 +784,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1280,7 +1280,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1304,7 +1304,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1541,7 +1541,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1653,7 +1653,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1695,7 +1695,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1729,7 +1729,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2139,7 +2139,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2423,7 +2423,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2490,9 +2490,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3504,7 +3504,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4147,9 +4147,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4196,7 +4196,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4262,7 +4262,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4296,7 +4296,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4897,7 +4897,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5063,7 +5063,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5516,9 +5516,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -5905,7 +5905,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7139,7 +7139,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9684,7 +9684,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9694,7 +9694,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -9983,7 +9983,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.0.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.0.2.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.0.2.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.0.2.RELEASE/spring-cloud-contract.xml
@@ -246,7 +246,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -492,7 +492,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -781,9 +781,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1276,7 +1276,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1300,7 +1300,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1537,7 +1537,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1649,7 +1649,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1691,7 +1691,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1725,7 +1725,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2143,7 +2143,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2427,7 +2427,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2494,9 +2494,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3508,7 +3508,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4151,9 +4151,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4200,7 +4200,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4266,7 +4266,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4300,7 +4300,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4890,7 +4890,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5056,7 +5056,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5507,9 +5507,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -5896,7 +5896,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7130,7 +7130,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9705,7 +9705,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9715,7 +9715,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10004,7 +10004,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.0.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.0.3.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.0.3.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.0.3.RELEASE/spring-cloud-contract.xml
@@ -246,7 +246,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -492,7 +492,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -781,9 +781,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1276,7 +1276,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1300,7 +1300,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1537,7 +1537,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1649,7 +1649,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1691,7 +1691,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1725,7 +1725,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2143,7 +2143,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2427,7 +2427,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2494,9 +2494,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3508,7 +3508,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4151,9 +4151,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4200,7 +4200,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4266,7 +4266,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4300,7 +4300,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4890,7 +4890,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5056,7 +5056,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5507,9 +5507,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -5896,7 +5896,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7131,7 +7131,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9784,7 +9784,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9794,7 +9794,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10083,7 +10083,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.M1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.M1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.M1/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.M1/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -495,7 +495,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -784,9 +784,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1279,7 +1279,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1303,7 +1303,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1540,7 +1540,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1652,7 +1652,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1694,7 +1694,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1728,7 +1728,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2077,7 +2077,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2361,7 +2361,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2428,9 +2428,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3476,7 +3476,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4119,9 +4119,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4168,7 +4168,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4234,7 +4234,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4268,7 +4268,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4858,7 +4858,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5024,7 +5024,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5475,9 +5475,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -5866,7 +5866,7 @@ the <literal>Contract</literal> class: <literal>import org.springframework.cloud
 				"id":"01fbe706f872cb32",
 				"name":"Washington",
 				"place_type":"city",
-				"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+				"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 			}
 		}]
 	'''
@@ -7100,7 +7100,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9684,7 +9684,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9694,7 +9694,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -9983,7 +9983,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.M2/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.M2/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.M2/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.M2/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -807,9 +807,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1302,7 +1302,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1326,7 +1326,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1563,7 +1563,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1675,7 +1675,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1717,7 +1717,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1751,7 +1751,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2108,7 +2108,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2392,7 +2392,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2459,9 +2459,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3468,7 +3468,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4111,9 +4111,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4160,7 +4160,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4226,7 +4226,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4260,7 +4260,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4877,7 +4877,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5043,7 +5043,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5603,9 +5603,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7120,7 +7120,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9688,7 +9688,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9699,7 +9699,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -9987,7 +9987,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.RC1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.RC1/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.RC1/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.RC1/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -807,9 +807,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1302,7 +1302,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1326,7 +1326,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1563,7 +1563,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1675,7 +1675,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1717,7 +1717,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1751,7 +1751,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2108,7 +2108,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2392,7 +2392,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2459,9 +2459,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3468,7 +3468,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4111,9 +4111,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4160,7 +4160,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4226,7 +4226,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4260,7 +4260,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4877,7 +4877,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5043,7 +5043,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5603,9 +5603,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7237,7 +7237,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9805,7 +9805,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9816,7 +9816,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10104,7 +10104,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.RC2/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.RC2/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.RC2/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.RC2/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -807,9 +807,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1302,7 +1302,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1326,7 +1326,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1563,7 +1563,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1675,7 +1675,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1717,7 +1717,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1751,7 +1751,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2108,7 +2108,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2392,7 +2392,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2459,9 +2459,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3468,7 +3468,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4111,9 +4111,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4160,7 +4160,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4226,7 +4226,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4260,7 +4260,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4877,7 +4877,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5043,7 +5043,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5603,9 +5603,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7237,7 +7237,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9805,7 +9805,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9816,7 +9816,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10104,7 +10104,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.RC3/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.RC3/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.RC3/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.RC3/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -807,9 +807,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1301,7 +1301,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1325,7 +1325,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1562,7 +1562,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1674,7 +1674,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1716,7 +1716,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1750,7 +1750,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2107,7 +2107,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2391,7 +2391,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2458,9 +2458,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3481,7 +3481,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4124,9 +4124,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4173,7 +4173,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4239,7 +4239,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4273,7 +4273,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -4890,7 +4890,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5056,7 +5056,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5616,9 +5616,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7299,7 +7299,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -9924,7 +9924,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -9935,7 +9935,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10223,7 +10223,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.0.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.0.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.0.RELEASE/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -807,9 +807,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1303,7 +1303,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1327,7 +1327,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1564,7 +1564,7 @@ one to one to the contents of the repo.</simpara>
 <simpara>Example of a <literal>pom.xml</literal> inside the <literal>server</literal> folder.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1676,7 +1676,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>The <literal>pom.xml</literal> in the root folder can look like this:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1718,7 +1718,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1752,7 +1752,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2259,7 +2259,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2543,7 +2543,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2610,9 +2610,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3652,7 +3652,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4295,9 +4295,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4344,7 +4344,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4410,7 +4410,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4444,7 +4444,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -5121,7 +5121,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5287,7 +5287,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)
@@ -5847,9 +5847,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7530,7 +7530,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -10332,7 +10332,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -10343,7 +10343,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10631,7 +10631,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-contract/2.1.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
+++ b/spring-cloud-contract/2.1.1.RELEASE/spring-cloud-contract-maven-plugin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-contract/2.1.1.RELEASE/spring-cloud-contract.xml
+++ b/spring-cloud-contract/2.1.1.RELEASE/spring-cloud-contract.xml
@@ -249,7 +249,7 @@ pass the stub artifact IDs and artifact repository URL as <literal>Spring Cloud 
 Stub Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -518,7 +518,7 @@ pass the stub artifact IDs and artifact repository URl as <literal>Spring Cloud 
 Runner</literal> properties, as shown in the following example:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 </listitem>
 </itemizedlist>
 <simpara>Now you can annotate your test class with <literal>@AutoConfigureStubRunner</literal>. In the annotation,
@@ -822,9 +822,9 @@ following section to your build:</simpara>
 <programlisting language="groovy" linenumbering="unnumbered">repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }</programlisting>
 </para>
 </formalpara>
@@ -1351,7 +1351,7 @@ side are automatically downloaded from Nexus/Artifactory. You can set the value 
 achieving the same thing by changing the properties.</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot</programlisting>
+  repositoryRoot: https://repo.spring.io/libs-snapshot</programlisting>
 <simpara>That&#8217;s it!</simpara>
 </section>
 </section>
@@ -1375,7 +1375,7 @@ constant development.</simpara>
 <title>Readings</title>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
+<simpara><link xl:href="https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura">Slides from Marcin Grzejszczak&#8217;s talk about Accurest</link></simpara>
 </listitem>
 <listitem>
 <simpara><link xl:href="http://toomuchcoding.com/blog/categories/accurest/">Accurest related articles from Marcin Grzejszczak&#8217;s blog</link></simpara>
@@ -1613,7 +1613,7 @@ one to one to the contents of the repo.</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -1728,7 +1728,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <programlisting language="xml" linenumbering="unnumbered">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example.standalone&lt;/groupId&gt;
@@ -1772,7 +1772,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 <simpara>It&#8217;s using the assembly plugin in order to build the JAR with all the contracts. Example of such setup is here:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
-		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+		  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;project&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -1806,7 +1806,7 @@ Those poms are necessary for the consumer side to run <literal>mvn clean install
 consumer team clones the common repository, goes to the required producer&#8217;s folder (e.g. <literal>com/example/server</literal>)
 and runs <literal>mvn clean install -DskipTests</literal> to install locally the stubs converted from the contracts.</simpara>
 <tip>
-<simpara>You need to have <link xl:href="http://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
+<simpara>You need to have <link xl:href="https://maven.apache.org/download.cgi">Maven installed locally</link></simpara>
 </tip>
 </section>
 <section xml:id="_producer">
@@ -2316,7 +2316,7 @@ to find stub definitions and contracts. E.g. for <literal>com.example:foo:1.0.0<
 </section>
 <section xml:id="_can_i_use_the_pact_broker">
 <title>Can I use the Pact Broker?</title>
-<simpara>When using <link xl:href="http://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
+<simpara>When using <link xl:href="https://pact.io/">Pact</link> you can use the <link xl:href="https://github.com/pact-foundation/pact_broker">Pact Broker</link>
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.</simpara>
@@ -2600,7 +2600,7 @@ following sections:</simpara>
 Gradle or a Maven plugin.</simpara>
 <warning>
 <simpara>If you want to use Spock in your projects, you must add separately the
-<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="http://spockframework.github.io/">Spock
+<literal>spock-core</literal> and <literal>spock-spring</literal> modules. Check <link xl:href="https://spockframework.github.io/">Spock
 docs for more information</link></simpara>
 </warning>
 </section>
@@ -2667,9 +2667,9 @@ which are automatically uploaded after every successful build, as shown here:</s
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}
 }</programlisting>
 </section>
@@ -3709,7 +3709,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be <link xl:href="https://jfrog.com/artifactory/">Artifactory</link>
-or <link xl:href="http://www.sonatype.org/nexus/">Nexus</link>.</simpara>
+or <link xl:href="https://www.sonatype.org/nexus/">Nexus</link>.</simpara>
 </listitem>
 </itemizedlist>
 </section>
@@ -4352,9 +4352,9 @@ versions, which are automatically uploaded after every successful build:</simpar
 	repositories {
 		mavenCentral()
 		mavenLocal()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/release" }
 	}</programlisting>
 </para>
 </formalpara>
@@ -4401,7 +4401,7 @@ it if you want to.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;
@@ -4467,7 +4467,7 @@ publishing {
 <section xml:id="_stub_runner_core">
 <title>Stub Runner Core</title>
 <simpara>Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of
-<link xl:href="http://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
+<link xl:href="https://martinfowler.com/articles/consumerDrivenContracts.html">Consumer Driven Contracts</link>.</simpara>
 <simpara>Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.</simpara>
 <section xml:id="_retrieving_stubs">
@@ -4501,7 +4501,7 @@ For messaging, special stub routes are defined.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>Example:</simpara>
-<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
+<programlisting language="java" linenumbering="unnumbered">@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)</programlisting>
 </section>
 <section xml:id="_classpath_scanning">
 <title>Classpath scanning</title>
@@ -5235,7 +5235,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 </section>
 <section xml:id="_spring_cloud_cli">
 <title>Spring Cloud CLI</title>
-<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="http://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
+<simpara>Starting from <literal>1.4.0.RELEASE</literal> version of the <link xl:href="https://cloud.spring.io/spring-cloud-cli">Spring Cloud CLI</link>
 project you can start Stub Runner Boot by executing <literal>spring cloud stubrunner</literal>.</simpara>
 <simpara>In order to pass the configuration just create a <literal>stubrunner.yml</literal> file in the current working directory
 or a subdirectory called <literal>config</literal> or in <literal>~/.spring-cloud</literal>. The file could look like this
@@ -5402,7 +5402,7 @@ and we want to have the stub runner feature turned on <literal>@AutoConfigureStu
 <simpara>Now let&#8217;s assume that we want to start this application so that the stubs get automatically registered.
  We can do it by running the app <literal>java -jar ${SYSTEM_PROPS} stub-runner-boot-eureka-example.jar</literal> where
  <literal>${SYSTEM_PROPS}</literal> would contain the following list of properties</simpara>
-<programlisting language="bash" linenumbering="unnumbered">* -Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+<programlisting language="bash" linenumbering="unnumbered">* -Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 * -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 * -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.
 * springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.
@@ -5973,9 +5973,9 @@ classpath. Remember to annotate your test class with <literal>@AutoConfigureStub
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xmlns="http://www.springframework.org/schema/integration"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
+			https://www.springframework.org/schema/integration/spring-integration.xsd"&gt;
 
 
 	&lt;!-- REQUIRED FOR TESTING --&gt;
@@ -7680,7 +7680,7 @@ matches the JSON Path.</simpara>
 </listitem>
 </itemizedlist>
 <simpara>If you&#8217;re using the YAML contract definition you have to use the
-<link xl:href="http://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
+<link xl:href="https://handlebarsjs.com/">Handlebars</link> <literal>{{{ }}}</literal> notation with custom, Spring Cloud Contract
  functions to achieve this.</simpara>
 <itemizedlist>
 <listitem>
@@ -10528,7 +10528,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -10539,7 +10539,7 @@ public class WiremockForDocsMockServerApplicationTests {
 <simpara>The <literal>baseUrl</literal> value is prepended to all mock calls, and the <literal>stubs()</literal> method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 <literal>/stubs/resource.json</literal> is loaded into the mock server. If the <literal>RestTemplate</literal> is asked to
-visit <literal><link xl:href="http://example.org/">http://example.org/</link></literal>, it gets the responses as being declared at that URL. More
+visit <literal><link xl:href="https://example.org/">https://example.org/</link></literal>, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -10827,7 +10827,7 @@ structure presented in the previous snippet.</simpara>
 &lt;assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd"&gt;
 	&lt;id&gt;stubs&lt;/id&gt;
 	&lt;formats&gt;
 		&lt;format&gt;jar&lt;/format&gt;

--- a/spring-cloud-function/1.0.0.RELEASE/spring-cloud-function.xml
+++ b/spring-cloud-function/1.0.0.RELEASE/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.M1/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.M1/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.M2/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.M2/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.M4/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.M4/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.RC1/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.RC1/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.RC2/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.RC2/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.RC3/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.RC3/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.0.RELEASE/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.0.RELEASE/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-function/2.0.1.RELEASE/spring-cloud-function.xml
+++ b/spring-cloud-function/2.0.1.RELEASE/spring-cloud-function.xml
@@ -48,7 +48,7 @@ public class Application {
 <simpara>It&#8217;s just a Spring Boot application, so it can be built, run and
 tested, locally and in a CI build, the same way as any other Spring
 Boot application. The <literal>Function</literal> is from <literal>java.util</literal> and <literal>Flux</literal> is a
-<link xl:href="http://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
+<link xl:href="https://www.reactive-streams.org/">Reactive Streams</link> <literal>Publisher</literal> from
 <link xl:href="https://projectreactor.io/">Project Reactor</link>. The function can be
 accessed over HTTP or messaging.</simpara>
 <simpara>Spring Cloud Function has 4 main features:</simpara>

--- a/spring-cloud-gateway/1.0.0.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/1.0.0.RELEASE/spring-cloud-gateway.xml
@@ -13,7 +13,7 @@
 </preface>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
-<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </chapter>
 <chapter xml:id="_building_a_gateway_using_spring_mvc">
 <title>Building a Gateway Using Spring MVC</title>

--- a/spring-cloud-gateway/1.0.1.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/1.0.1.RELEASE/spring-cloud-gateway.xml
@@ -13,7 +13,7 @@
 </preface>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
-<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </chapter>
 <chapter xml:id="_building_a_gateway_using_spring_mvc">
 <title>Building a Gateway Using Spring MVC</title>

--- a/spring-cloud-gateway/1.0.2.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/1.0.2.RELEASE/spring-cloud-gateway.xml
@@ -13,7 +13,7 @@
 </preface>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
-<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </chapter>
 <chapter xml:id="_building_a_gateway_using_spring_mvc">
 <title>Building a Gateway Using Spring MVC</title>

--- a/spring-cloud-gateway/2.0.0.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.0.0.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -432,7 +432,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -450,7 +450,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -497,7 +497,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -524,7 +524,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -545,12 +545,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -595,7 +595,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -613,7 +613,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -631,7 +631,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -643,7 +643,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -652,14 +652,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -731,7 +731,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -751,7 +751,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -769,11 +769,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -945,13 +945,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.0.1.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.0.1.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -432,7 +432,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -450,7 +450,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -496,7 +496,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -523,7 +523,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -544,12 +544,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -594,7 +594,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -612,7 +612,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -630,7 +630,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -642,7 +642,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -651,14 +651,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -730,7 +730,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -750,7 +750,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -768,11 +768,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1046,13 +1046,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.0.2.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.0.2.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -432,7 +432,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -450,7 +450,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -496,7 +496,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -523,7 +523,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -544,12 +544,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -594,7 +594,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -612,7 +612,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -630,7 +630,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -642,7 +642,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -651,14 +651,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -730,7 +730,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -750,7 +750,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -768,11 +768,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1064,13 +1064,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.0.3.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.0.3.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host={sub}.somehost.org</programlisting>
 </para>
@@ -174,7 +174,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -215,7 +215,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -229,7 +229,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -247,7 +247,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -334,7 +334,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -352,7 +352,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -370,7 +370,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -381,7 +381,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -391,7 +391,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -438,7 +438,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -456,7 +456,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -503,7 +503,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -530,7 +530,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -551,12 +551,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removehopbyhopheadersfilter_gatewayfilter_factory">
 <title>RemoveHopByHopHeadersFilter GatewayFilter Factory</title>
@@ -601,7 +601,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -619,7 +619,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -637,7 +637,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -657,7 +657,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -667,7 +667,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -676,14 +676,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -755,7 +755,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -775,7 +775,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -793,11 +793,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1097,13 +1097,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1188,7 +1188,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1306,7 +1306,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gateway/2.1.0.M1/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.M1/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -432,7 +432,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -450,7 +450,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -496,7 +496,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -523,7 +523,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -544,12 +544,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -594,7 +594,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -612,7 +612,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -630,7 +630,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -642,7 +642,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -651,14 +651,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -730,7 +730,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -750,7 +750,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -768,11 +768,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1072,13 +1072,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.1.0.M2/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.M2/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -515,7 +515,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -533,7 +533,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -579,7 +579,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -606,7 +606,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -627,12 +627,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -677,7 +677,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -695,7 +695,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -713,7 +713,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -725,7 +725,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -734,14 +734,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -813,7 +813,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -833,7 +833,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -851,11 +851,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1173,13 +1173,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.1.0.M3/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.M3/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -172,7 +172,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -190,7 +190,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -209,7 +209,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -223,7 +223,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -241,7 +241,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -328,7 +328,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -346,7 +346,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -364,7 +364,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -375,7 +375,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -385,7 +385,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -515,7 +515,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -533,7 +533,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -579,7 +579,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -606,7 +606,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -627,12 +627,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -677,7 +677,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -695,7 +695,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -713,7 +713,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -733,7 +733,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -743,7 +743,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -752,14 +752,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -831,7 +831,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -851,7 +851,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -869,11 +869,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1191,13 +1191,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/spring-cloud-gateway/2.1.0.RC1/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.RC1/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -174,7 +174,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -215,7 +215,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -229,7 +229,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -247,7 +247,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -334,7 +334,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -352,7 +352,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -370,7 +370,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -381,7 +381,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -391,7 +391,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -521,7 +521,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -539,7 +539,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -586,7 +586,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -613,7 +613,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -634,12 +634,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -684,7 +684,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -702,7 +702,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -720,7 +720,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -740,7 +740,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -750,7 +750,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -759,14 +759,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -838,7 +838,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -858,7 +858,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -876,11 +876,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1200,13 +1200,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1287,7 +1287,7 @@ public RouteLocator customRouteLocator(RouteLocatorBuilder builder, ThrottleGate
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1405,7 +1405,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gateway/2.1.0.RC2/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.RC2/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -174,7 +174,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -215,7 +215,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -229,7 +229,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -247,7 +247,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -334,7 +334,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -352,7 +352,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -370,7 +370,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -381,7 +381,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -391,7 +391,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -521,7 +521,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -539,7 +539,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -586,7 +586,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -613,7 +613,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -634,12 +634,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -684,7 +684,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -702,7 +702,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -720,7 +720,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -740,7 +740,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -750,7 +750,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -759,14 +759,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -838,7 +838,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -858,7 +858,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -876,11 +876,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1200,13 +1200,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1287,7 +1287,7 @@ public RouteLocator customRouteLocator(RouteLocatorBuilder builder, ThrottleGate
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1405,7 +1405,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gateway/2.1.0.RC3/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.RC3/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -174,7 +174,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -215,7 +215,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -229,7 +229,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -247,7 +247,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -334,7 +334,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -352,7 +352,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -370,7 +370,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -381,7 +381,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -391,7 +391,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -521,7 +521,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -539,7 +539,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -586,7 +586,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -613,7 +613,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -634,12 +634,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -684,7 +684,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -702,7 +702,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -720,7 +720,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -740,7 +740,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -750,7 +750,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -759,14 +759,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -838,7 +838,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -858,7 +858,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -876,11 +876,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1252,13 +1252,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1366,7 +1366,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1484,7 +1484,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gateway/2.1.0.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.0.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -28,10 +28,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -64,7 +64,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -82,7 +82,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -100,7 +100,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -118,7 +118,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -136,7 +136,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -174,7 +174,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -215,7 +215,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -229,7 +229,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -247,7 +247,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -334,7 +334,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -352,7 +352,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -370,7 +370,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -381,7 +381,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -391,7 +391,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -521,7 +521,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -539,7 +539,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -586,7 +586,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -613,7 +613,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -634,12 +634,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -684,7 +684,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -702,7 +702,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -720,7 +720,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -740,7 +740,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -750,7 +750,7 @@ KeyResolver userKeyResolver() {
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -759,14 +759,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -838,7 +838,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -858,7 +858,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -876,11 +876,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1265,13 +1265,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1379,7 +1379,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1497,7 +1497,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gateway/2.1.1.RELEASE/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway/2.1.1.RELEASE/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -37,10 +37,10 @@ working with Spring Cloud Gateway.</simpara>
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -73,7 +73,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -91,7 +91,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -109,7 +109,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -127,7 +127,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -145,7 +145,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -163,7 +163,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -183,7 +183,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -201,7 +201,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -224,7 +224,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -238,7 +238,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -256,7 +256,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -343,7 +343,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -361,7 +361,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -379,7 +379,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -390,7 +390,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -400,7 +400,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -530,7 +530,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -548,7 +548,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -595,7 +595,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -622,7 +622,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -643,12 +643,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removehopbyhopheadersfilter_gatewayfilter_factory">
 <title>RemoveHopByHopHeadersFilter GatewayFilter Factory</title>
@@ -693,7 +693,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -711,7 +711,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -732,7 +732,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -752,7 +752,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -762,7 +762,7 @@ and have it applied to all routes.</simpara>
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -771,14 +771,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -850,7 +850,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -870,7 +870,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -888,11 +888,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1293,13 +1293,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1407,7 +1407,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1525,7 +1525,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/spring-cloud-gcp/1.1.0.RC1/spring-cloud-gcp.xml
+++ b/spring-cloud-gcp/1.1.0.RC1/spring-cloud-gcp.xml
@@ -128,7 +128,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>GCP Support</simpara>
@@ -342,7 +342,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -467,7 +467,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -1413,7 +1413,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <simpara>A <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample">sample application</link> is available.</simpara>
 <section xml:id="_web_mvc_interceptor">
@@ -1691,7 +1691,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Also note that core properties as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link> do not apply to Spring Cloud GCP Config.</simpara>
@@ -1735,7 +1735,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -1765,7 +1765,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -1776,8 +1776,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -2998,8 +2998,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -4154,7 +4154,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, then you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>

--- a/spring-cloud-gcp/1.1.0.RC2/spring-cloud-gcp.xml
+++ b/spring-cloud-gcp/1.1.0.RC2/spring-cloud-gcp.xml
@@ -128,7 +128,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>GCP Support</simpara>
@@ -346,7 +346,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -471,7 +471,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -1423,7 +1423,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <simpara>A <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample">sample application</link> is available.</simpara>
 <section xml:id="_web_mvc_interceptor">
@@ -1701,7 +1701,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Also note that core properties as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link> do not apply to Spring Cloud GCP Config.</simpara>
@@ -1745,7 +1745,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -1775,7 +1775,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -1786,8 +1786,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -2988,8 +2988,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -4160,7 +4160,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, then you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; you may consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> as a reference.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>

--- a/spring-cloud-gcp/1.1.0.RELEASE/spring-cloud-gcp.xml
+++ b/spring-cloud-gcp/1.1.0.RELEASE/spring-cloud-gcp.xml
@@ -137,7 +137,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
 <section xml:id="_gcp_support">
 <title>GCP Support</title>
 <simpara>The GCP Support entry contains auto-configuration support for every Spring Cloud GCP integration.
@@ -361,7 +361,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -487,7 +487,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -1437,7 +1437,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <section xml:id="_web_mvc_interceptor">
 <title>Web MVC Interceptor</title>
@@ -1718,7 +1718,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Core properties, as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link>, do not apply to Spring Cloud GCP Config.</simpara>
@@ -1764,7 +1764,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -1794,7 +1794,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -1805,8 +1805,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -3019,8 +3019,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -4202,7 +4202,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>

--- a/spring-cloud-gcp/1.1.1.RELEASE/spring-cloud-gcp.xml
+++ b/spring-cloud-gcp/1.1.1.RELEASE/spring-cloud-gcp.xml
@@ -137,7 +137,7 @@ For simplicity, the Gradle dependency snippets in the remainder of this document
 <simpara>There are many available resources to get you up to speed with our libraries as quickly as possible.</simpara>
 <section xml:id="_spring_initializr">
 <title>Spring Initializr</title>
-<simpara>There are three entries in <link xl:href="http://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
+<simpara>There are three entries in <link xl:href="https://start.spring.io/">Spring Initializr</link> for Spring Cloud GCP.</simpara>
 <section xml:id="_gcp_support">
 <title>GCP Support</title>
 <simpara>The GCP Support entry contains auto-configuration support for every Spring Cloud GCP integration.
@@ -361,7 +361,7 @@ The provider can help determine programmatically in which GCP environment (App E
 </section>
 <section xml:id="_spring_initializr_2">
 <title>Spring Initializr</title>
-<simpara>This starter is available from <link xl:href="http://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
+<simpara>This starter is available from <link xl:href="https://start.spring.io/">Spring Initializr</link> through the <literal>GCP Support</literal> entry.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_google_cloud_pubsub">
@@ -487,7 +487,7 @@ The Spring Boot starter for GCP Pub/Sub auto-configures a <literal>PubSubAdmin</
 <programlisting language="java" linenumbering="unnumbered">public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)</programlisting>
 <simpara>Here is an example of how to create a Google Cloud Pub/Sub subscription:</simpara>
 <programlisting language="java" linenumbering="unnumbered">public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “http://my.endpoint/push”);
+    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
 }</programlisting>
 <simpara>Alternative methods with default settings are provided for ease of use.
 The default value for <literal>ackDeadline</literal> is 10 seconds.
@@ -1437,7 +1437,7 @@ This allows grouping of log messages by request, for example, in the <link xl:hr
 <note>
 <simpara>Due to the way logging is set up, the GCP project ID and credentials defined in <literal>application.properties</literal> are ignored.
 Instead, you should set the <literal>GOOGLE_CLOUD_PROJECT</literal> and <literal>GOOGLE_APPLICATION_CREDENTIALS</literal> environment variables to the project ID and credentials private key location, respectively.
-You can do this easily if you&#8217;re using the <link xl:href="http://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
+You can do this easily if you&#8217;re using the <link xl:href="https://cloud.google.com/sdk">Google Cloud SDK</link>, using the <literal>gcloud config set project [YOUR_PROJECT_ID]</literal> and <literal>gcloud auth application-default login</literal> commands, respectively.</simpara>
 </note>
 <section xml:id="_web_mvc_interceptor">
 <title>Web MVC Interceptor</title>
@@ -1718,7 +1718,7 @@ If more than a single profile, last one is chosen</simpara></entry>
 </tgroup>
 </informaltable>
 <note>
-<simpara>These properties should be specified in a <link xl:href="http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
+<simpara>These properties should be specified in a <link xl:href="https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context"><literal>bootstrap.yml</literal>/<literal>bootstrap.properties</literal></link> file, rather than the usual <literal>applications.yml</literal>/<literal>application.properties</literal>.</simpara>
 </note>
 <note>
 <simpara>Core properties, as described in <link linkend="spring-cloud-gcp-core">Spring Cloud GCP Core Module</link>, do not apply to Spring Cloud GCP Config.</simpara>
@@ -1764,7 +1764,7 @@ public class SampleConfig {
 </section>
 <section xml:id="_refreshing_the_configuration_at_runtime">
 <title>Refreshing the configuration at runtime</title>
-<simpara><link xl:href="http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
+<simpara><link xl:href="https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html#_endpoints">Spring Cloud</link> provides support to have configuration parameters be reloadable with the POST request to <literal>/actuator/refresh</literal> endpoint.</simpara>
 <orderedlist numeration="arabic">
 <listitem>
 <simpara>Add the Spring Boot Actuator dependency:</simpara>
@@ -1794,7 +1794,7 @@ public class SampleConfig {
 </listitem>
 <listitem>
 <simpara>Send a POST request to the refresh endpoint:</simpara>
-<literallayout class="monospaced">$ curl -XPOST http://myapp.host.com/actuator/refresh</literallayout>
+<literallayout class="monospaced">$ curl -XPOST https://myapp.host.com/actuator/refresh</literallayout>
 </listitem>
 </orderedlist>
 </section>
@@ -1805,8 +1805,8 @@ public class SampleConfig {
 </chapter>
 <chapter xml:id="_spring_data_cloud_spanner">
 <title>Spring Data Cloud Spanner</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/spanner/">Google Cloud Spanner</link>.</simpara>
 <simpara>Maven coordinates for this module only, using Spring Cloud GCP BOM:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -3019,8 +3019,8 @@ public void createTable(SpannerPersistentEntity entity) {
 </chapter>
 <chapter xml:id="_spring_data_cloud_datastore">
 <title>Spring Data Cloud Datastore</title>
-<simpara><link xl:href="http://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
-Spring Cloud GCP adds Spring Data support for <link xl:href="http://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
+<simpara><link xl:href="https://projects.spring.io/spring-data/">Spring Data</link> is an abstraction for storing and retrieving POJOs in numerous storage technologies.
+Spring Cloud GCP adds Spring Data support for <link xl:href="https://cloud.google.com/datastore/">Google Cloud Datastore</link>.</simpara>
 <simpara>Maven coordinates for this module only, using <link xl:href="https://github.com/spring-cloud/spring-cloud-gcp/blob/master/spring-cloud-gcp-dependencies/pom.xml">Spring Cloud GCP BOM</link>:</simpara>
 <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.springframework.cloud&lt;/groupId&gt;
@@ -4202,7 +4202,7 @@ A full list of Cloud Vision Features is provided in the <link xl:href="https://c
 <simpara><link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse"><literal>AnnotateImageResponse</literal></link> contains the results of all the feature analyses that were specified in the request.
 For each feature type that you provide in the request, <literal>AnnotateImageResponse</literal> provides a getter method to get the result of that feature analysis.
 For example, if you analyzed an image using the <literal>LABEL_DETECTION</literal> feature, you would retrieve the results from the response using <literal>annotateImageResponse.getLabelAnnotationsList()</literal>.</simpara>
-<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
+<simpara><literal>AnnotateImageResponse</literal> is provided by the Google Cloud Vision libraries; please consult the <link xl:href="https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.AnnotateImageResponse">RPC reference</link> or <link xl:href="https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html">Javadoc</link> for more details.
 Additionally, you may consult the <link xl:href="https://cloud.google.com/vision/docs/">Cloud Vision docs</link> to familiarize yourself with the concepts and features of the API.</simpara>
 </listitem>
 </itemizedlist>

--- a/spring-cloud-kubernetes/1.0.0.M2/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/1.0.0.M2/spring-cloud-kubernetes.xml
@@ -15,8 +15,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <title>DiscoveryClient for Kubernetes</title>
 <partintro>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -53,7 +53,7 @@ variables.</simpara>
 </partintro>
 <chapter xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -664,7 +664,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -688,13 +688,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -751,7 +751,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -778,7 +778,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-kubernetes/1.0.0.RC1/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/1.0.0.RC1/spring-cloud-kubernetes.xml
@@ -14,8 +14,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -49,7 +49,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -656,7 +656,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -689,7 +689,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -713,13 +713,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -776,7 +776,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -803,7 +803,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-kubernetes/1.0.0.RC2/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/1.0.0.RC2/spring-cloud-kubernetes.xml
@@ -14,8 +14,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -64,7 +64,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -599,7 +599,7 @@ within the Kubernetes platform <emphasis role="strong">(e.g. different dev and p
 <section xml:id="_istio_awareness">
 <title>Istio Awareness</title>
 <simpara>When including the <emphasis role="strong">spring-cloud-kubernetes-istio</emphasis> module into the application classpath a new profile will be added to the application,
-if the application is running inside a Kubernetes Cluster with <link xl:href="http://istio.io">Istio</link> installed. Then you can use
+if the application is running inside a Kubernetes Cluster with <link xl:href="https://istio.io">Istio</link> installed. Then you can use
 spring <emphasis role="strong">@Profile("istio")</emphasis> annotations into your Beans and <emphasis role="strong">@Configuration</emphasis>'s.</simpara>
 <simpara>The Istio awareness module uses the <emphasis role="strong">me.snowdrop:istio-client</emphasis> to interact with Istio APIs enabling us to discover traffic rules, circuit breakers, etc.
 Making it easy for our Spring Boot applications to consume this data to dynamically configure themselves according the environment.</simpara>
@@ -684,7 +684,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -717,7 +717,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -741,13 +741,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -804,7 +804,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -831,7 +831,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-kubernetes/1.0.0.RELEASE/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/1.0.0.RELEASE/spring-cloud-kubernetes.xml
@@ -14,8 +14,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -64,7 +64,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -608,7 +608,7 @@ within the Kubernetes platform <emphasis role="strong">(e.g. different dev and p
 <section xml:id="_istio_awareness">
 <title>Istio Awareness</title>
 <simpara>When including the <emphasis role="strong">spring-cloud-kubernetes-istio</emphasis> module into the application classpath a new profile will be added to the application,
-if the application is running inside a Kubernetes Cluster with <link xl:href="http://istio.io">Istio</link> installed. Then you can use
+if the application is running inside a Kubernetes Cluster with <link xl:href="https://istio.io">Istio</link> installed. Then you can use
 spring <emphasis role="strong">@Profile("istio")</emphasis> annotations into your Beans and <emphasis role="strong">@Configuration</emphasis>'s.</simpara>
 <simpara>The Istio awareness module uses the <emphasis role="strong">me.snowdrop:istio-client</emphasis> to interact with Istio APIs enabling us to discover traffic rules, circuit breakers, etc.
 Making it easy for our Spring Boot applications to consume this data to dynamically configure themselves according the environment.</simpara>
@@ -693,7 +693,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -726,7 +726,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -750,13 +750,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -813,7 +813,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -840,7 +840,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-kubernetes/1.0.1.RELEASE/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/1.0.1.RELEASE/spring-cloud-kubernetes.xml
@@ -825,7 +825,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -849,13 +849,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -912,7 +912,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -939,7 +939,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>
@@ -1032,7 +1032,7 @@ message (where XXXX is the issue number).</simpara>
 <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd"&gt;
 &lt;suppressions&gt;
 	&lt;suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/&gt;
 	&lt;suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/&gt;

--- a/spring-cloud-kubernetes/2.1.0.RC1/spring-cloud-kubernetes.xml
+++ b/spring-cloud-kubernetes/2.1.0.RC1/spring-cloud-kubernetes.xml
@@ -14,8 +14,8 @@ The main objective of the projects provided in this repository is to facilitate 
 <chapter xml:id="_discoveryclient_for_kubernetes">
 <title>DiscoveryClient for Kubernetes</title>
 <simpara>This project provides an implementation of <link xl:href="https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java">Discovery Client</link>
-for <link xl:href="http://kubernetes.io">Kubernetes</link>.
-This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="http://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
+for <link xl:href="https://kubernetes.io">Kubernetes</link>.
+This allows you to query Kubernetes endpoints <emphasis role="strong">(see <link xl:href="https://kubernetes.io/docs/user-guide/services/">services</link>)</emphasis> by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent <literal>http</literal>, <literal>https</literal> addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.</simpara>
@@ -49,7 +49,7 @@ application or Spring Boot starters. Users may override these properties by spec
 variables.</simpara>
 <section xml:id="_configmap_propertysource">
 <title>ConfigMap PropertySource</title>
-<simpara>Kubernetes provides a resource named <link xl:href="http://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
+<simpara>Kubernetes provides a resource named <link xl:href="https://kubernetes.io/docs/user-guide/configmap/">ConfigMap</link> to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded <literal>application.properties|yaml</literal> files.
 The <link xl:href="./spring-cloud-kubernetes-config">Spring Cloud Kubernetes Config</link> project makes Kubernetes `ConfigMap`s available
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
@@ -656,7 +656,7 @@ The same applies for PropertySourceLocator, where you need to add to the classpa
 <simpara><link xl:href="https://salaboy.com/2018/07/18/ljc-july-18-spring-cloud-docker-k8s/">Spring Cloud, Docker, Kubernetes &#8594; London Java Community July 2018</link></simpara>
 </listitem>
 </itemizedlist>
-<simpara>Please feel free to submit other resources via PR to <link xl:href="http://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
+<simpara>Please feel free to submit other resources via PR to <link xl:href="https://github.com/spring-cloud/spring-cloud-kubernetes">this repository</link>.</simpara>
 </chapter>
 <chapter xml:id="_building">
 <title>Building</title>
@@ -689,7 +689,7 @@ that you might find in "before_install" since they&#8217;re related to setting g
 credentials and you already have those.</simpara>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xl:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -713,13 +713,13 @@ a modified file in the correct place. Just commit it and push the change.</simpa
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipse</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <note>
@@ -776,7 +776,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -803,7 +803,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-netflix/1.3.5.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.3.5.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -76,7 +76,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
 <title>Authenticating with the Eureka Server</title>
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -310,7 +310,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -445,7 +445,7 @@ IP Address rather than its hostname.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -469,7 +469,7 @@ IP Address rather than its hostname.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -564,7 +564,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -584,7 +584,7 @@ To make turbine find the Hystrix stream at the correct port, you need to add <li
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -629,7 +629,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -833,7 +833,7 @@ This lazy loading behavior can be changed to instead eagerly load up these child
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1166,7 +1166,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1186,7 +1186,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1229,7 +1229,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1306,7 +1306,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor can you loadbalance multiple URLs with Ribbon.
@@ -1525,7 +1525,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1534,7 +1534,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2051,7 +2051,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.3.6.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.3.6.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -76,7 +76,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
 <title>Authenticating with the Eureka Server</title>
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -310,7 +310,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -445,7 +445,7 @@ IP Address rather than its hostname.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -469,7 +469,7 @@ IP Address rather than its hostname.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -564,7 +564,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -584,7 +584,7 @@ To make turbine find the Hystrix stream at the correct port, you need to add <li
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -629,7 +629,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -833,7 +833,7 @@ This lazy loading behavior can be changed to instead eagerly load up these child
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-feign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1166,7 +1166,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1186,7 +1186,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1229,7 +1229,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1306,7 +1306,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor can you loadbalance multiple URLs with Ribbon.
@@ -1525,7 +1525,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1534,7 +1534,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2051,7 +2051,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.0.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.0.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -335,7 +335,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -476,7 +476,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -500,7 +500,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -595,7 +595,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -616,7 +616,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -663,7 +663,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -959,7 +959,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1319,7 +1319,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1339,7 +1339,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1382,7 +1382,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1459,7 +1459,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1485,7 +1485,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1754,7 +1754,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1763,7 +1763,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2365,7 +2365,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.2.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.2.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -335,7 +335,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -476,7 +476,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -500,7 +500,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -595,7 +595,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -616,7 +616,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -663,7 +663,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -959,7 +959,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1319,7 +1319,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1339,7 +1339,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1382,7 +1382,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1459,7 +1459,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1485,7 +1485,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1754,7 +1754,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1763,7 +1763,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2365,7 +2365,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.3.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.3.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -335,7 +335,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -476,7 +476,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -500,7 +500,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -595,7 +595,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -616,7 +616,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -663,7 +663,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -959,7 +959,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1319,7 +1319,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1339,7 +1339,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1382,7 +1382,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1459,7 +1459,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1485,7 +1485,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1754,7 +1754,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1763,7 +1763,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2399,7 +2399,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.4.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.4.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -198,7 +198,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -335,7 +335,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -476,7 +476,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -500,7 +500,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -595,7 +595,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-hystrix-netflix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -616,7 +616,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -663,7 +663,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -959,7 +959,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1319,7 +1319,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1339,7 +1339,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1382,7 +1382,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1459,7 +1459,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1485,7 +1485,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    ListOfServers: http://example1.com,http://example2.com
+    ListOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1754,7 +1754,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1763,7 +1763,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2399,7 +2399,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.5.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.5.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -201,7 +201,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -338,7 +338,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -479,7 +479,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -503,7 +503,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -598,7 +598,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -619,7 +619,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -651,10 +651,10 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -678,7 +678,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -974,7 +974,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1334,7 +1334,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1354,7 +1354,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1397,7 +1397,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1474,7 +1474,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1500,7 +1500,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1769,7 +1769,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1778,7 +1778,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2414,7 +2414,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/1.4.6.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/1.4.6.RELEASE/spring-cloud-netflix.xml
@@ -22,7 +22,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).</simpara>
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include Eureka Client in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-client</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
@@ -75,7 +75,7 @@ by <literal>eureka.instance.*</literal> configuration keys, but the defaults wil
 fine if you ensure that your application has a
 <literal>spring.application.name</literal> (this is the default for the Eureka service
 ID, or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details of the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -201,7 +201,7 @@ implementing your own <literal>com.netflix.appinfo.HealthCheckHandler</literal>.
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, then the Eureka instance will have to be configured to be AWS aware and this can be done by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> the following way:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -338,7 +338,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-eureka-server</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
@@ -507,7 +507,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.  In a microservice architecture it is common to have multiple layers of service calls.</simpara>
 <figure>
 <title>Microservice Graph</title>
 <mediaobject>
@@ -531,7 +531,7 @@ example <literal>eureka.instance.hostname=${HOST_NAME}</literal>.</simpara>
 <section xml:id="netflix-hystrix-starter">
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example boot app:</simpara>
 <screen>@SpringBootApplication
@@ -626,7 +626,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.  You then visit <literal>/hystrix</literal> and point the dashboard to an individual instances <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -647,7 +647,7 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
   instance:
     metadata-map:
       management.port: ${management.port:8081}</screen>
-<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
+<simpara>The configuration key <literal>turbine.appConfig</literal> is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: <literal><link xl:href="https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME</link></literal> (the cluster parameter can be omitted if the name is "default"). The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":</simpara>
 <screen>turbine:
   aggregator:
     clusterConfig: CUSTOMERS
@@ -679,10 +679,10 @@ By default, metadata entry <literal>management.port</literal> is equal to the <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -706,7 +706,7 @@ annotation). Spring Cloud creates a new ensemble as an
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-ribbon</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
@@ -1002,7 +1002,7 @@ method.</simpara>
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Configuration
@@ -1362,7 +1362,7 @@ public class FooConfiguration {
 </chapter>
 <chapter xml:id="_external_configuration_archaius">
 <title>External Configuration: Archaius</title>
-<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
+<simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties.</simpara>
 <formalpara>
 <title>Archaius Example</title>
 <para>
@@ -1382,7 +1382,7 @@ public class FooConfiguration {
 <chapter xml:id="_router_and_filter_zuul">
 <title>Router and Filter: Zuul</title>
 <simpara>Routing in an integral part of a microservice architecture.  For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.  <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM based router and server side load balancer by Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1425,7 +1425,7 @@ public class FooConfiguration {
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-netflix-zuul</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
@@ -1502,7 +1502,7 @@ level, but "/myusers/**" matches hierarchically.</simpara>
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes don&#8217;t get executed as a <literal>HystrixCommand</literal> nor do they loadbalance multiple URLs with Ribbon.
@@ -1528,7 +1528,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1797,7 +1797,7 @@ but redirect some of the requests to new ones.</simpara>
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1806,7 +1806,7 @@ but redirect some of the requests to new ones.</simpara>
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In this example we are strangling the "legacy" app which is mapped to
@@ -2442,7 +2442,7 @@ it via the Zuul proxy.  If the serviceId of the ConfigServer is <literal>configs
 and the Sidecar is on port 5678, then it can be accessed at
 <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link></simpara>
 <simpara>Non-jvm app can take advantage of the Config Server&#8217;s ability to return YAML
-documents.  For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+documents.  For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document like the following</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.0.0.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.0.0.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -173,7 +173,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -296,7 +296,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -433,7 +433,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -463,7 +463,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -562,7 +562,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -589,7 +589,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -669,7 +669,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -961,7 +961,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -988,7 +988,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1032,7 +1032,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1089,7 +1089,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1115,7 +1115,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1342,7 +1342,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1351,7 +1351,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -1934,7 +1934,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.0.1.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.0.1.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -437,7 +437,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -467,7 +467,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -566,7 +566,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -593,7 +593,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -662,10 +662,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -685,7 +685,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -977,7 +977,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1004,7 +1004,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1048,7 +1048,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1105,7 +1105,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1131,7 +1131,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1358,7 +1358,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1367,7 +1367,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -1950,7 +1950,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.0.2.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.0.2.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -470,7 +470,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -500,7 +500,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -599,7 +599,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -626,7 +626,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -695,10 +695,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -718,7 +718,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1010,7 +1010,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1037,7 +1037,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1081,7 +1081,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1138,7 +1138,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1164,7 +1164,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1391,7 +1391,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1400,7 +1400,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -1983,7 +1983,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.0.3.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.0.3.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>. Eureka Discovery Client will also be disabled when <literal>spring.cloud.discovery.enabled</literal> is set to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -482,7 +482,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -512,7 +512,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -611,7 +611,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -638,7 +638,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -707,10 +707,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -730,7 +730,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1022,7 +1022,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1049,7 +1049,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1093,7 +1093,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1150,7 +1150,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1176,7 +1176,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1403,7 +1403,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1412,7 +1412,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -1650,12 +1650,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2029,7 +2029,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.M1/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.M1/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka &#8220;instance&#8221; (that is, it registers itself) and a &#8220;client&#8221; (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -437,7 +437,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -467,7 +467,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -566,7 +566,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -593,7 +593,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -662,10 +662,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -685,7 +685,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -977,7 +977,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1004,7 +1004,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1048,7 +1048,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1105,7 +1105,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1131,7 +1131,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1358,7 +1358,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1367,7 +1367,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the &#8220;legacy&#8221; application, which is mapped to all requests that do not match one of the other patterns.
@@ -1950,7 +1950,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.M2/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.M2/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -470,7 +470,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -500,7 +500,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -599,7 +599,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -626,7 +626,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -695,10 +695,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -718,7 +718,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1011,7 +1011,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1038,7 +1038,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1082,7 +1082,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1139,7 +1139,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1165,7 +1165,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1392,7 +1392,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1401,7 +1401,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1984,7 +1984,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.M3/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.M3/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="spring-cloud-running-eureka-server">
 <title>How to Run a Eureka Server</title>
@@ -470,7 +470,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -500,7 +500,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -599,7 +599,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -626,7 +626,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -695,10 +695,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -718,7 +718,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1011,7 +1011,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1038,7 +1038,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1082,7 +1082,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1139,7 +1139,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1165,7 +1165,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1392,7 +1392,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1401,7 +1401,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1622,12 +1622,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2001,7 +2001,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.RC1/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.RC1/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -502,7 +502,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -532,7 +532,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -631,7 +631,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -658,7 +658,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -727,10 +727,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -750,7 +750,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1043,7 +1043,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1070,7 +1070,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1114,7 +1114,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1171,7 +1171,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1197,7 +1197,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1424,7 +1424,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1433,7 +1433,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1671,12 +1671,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2050,7 +2050,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.RC2/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.RC2/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -502,7 +502,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -532,7 +532,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -631,7 +631,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -658,7 +658,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -727,10 +727,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -750,7 +750,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1043,7 +1043,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1070,7 +1070,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1114,7 +1114,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1171,7 +1171,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1197,7 +1197,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1424,7 +1424,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1433,7 +1433,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1671,12 +1671,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2050,7 +2050,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.RC3/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.RC3/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -502,7 +502,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -532,7 +532,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -631,7 +631,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -658,7 +658,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -727,10 +727,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -750,7 +750,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1043,7 +1043,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1070,7 +1070,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1114,7 +1114,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1171,7 +1171,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1197,7 +1197,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1424,7 +1424,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1433,7 +1433,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1671,12 +1671,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2050,7 +2050,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.0.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.0.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -502,7 +502,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -532,7 +532,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -631,7 +631,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -658,7 +658,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -727,10 +727,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -750,7 +750,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1043,7 +1043,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1070,7 +1070,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1114,7 +1114,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1171,7 +1171,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1197,7 +1197,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1424,7 +1424,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1433,7 +1433,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1671,12 +1671,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2050,7 +2050,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-netflix/2.1.1.RELEASE/spring-cloud-netflix.xml
+++ b/spring-cloud-netflix/2.1.1.RELEASE/spring-cloud-netflix.xml
@@ -25,7 +25,7 @@ The server can be configured and deployed to be highly available, with each serv
 <section xml:id="netflix-eureka-client-starter">
 <title>How to Include Eureka Client</title>
 <simpara>To include the Eureka Client in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of  <literal>spring-cloud-starter-netflix-eureka-client</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_registering_with_eureka">
 <title>Registering with Eureka</title>
@@ -62,7 +62,7 @@ By having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the c
 <simpara>The default application name (that is, the service ID), virtual host, and non-secure port (taken from the <literal>Environment</literal>) are <literal>${spring.application.name}</literal>, <literal>${spring.application.name}</literal> and <literal>${server.port}</literal>, respectively.</simpara>
 <simpara>Having <literal>spring-cloud-starter-netflix-eureka-client</literal> on the classpath makes the app into both a Eureka <quote>instance</quote> (that is, it registers itself) and a <quote>client</quote> (it can query the registry to locate other services).
 The instance behaviour is driven by <literal>eureka.instance.*</literal> configuration keys, but the defaults are fine if you ensure that your application has a value for <literal>spring.application.name</literal> (this is the default for the Eureka service ID or VIP).</simpara>
-<simpara>See <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
+<simpara>See <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> and <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java">EurekaClientConfigBean</link> for more details on the configurable options.</simpara>
 <simpara>To disable the Eureka Discovery Client, you can set <literal>eureka.client.enabled</literal> to <literal>false</literal>. Eureka Discovery Client will also be disabled when <literal>spring.cloud.discovery.enabled</literal> is set to <literal>false</literal>.</simpara>
 </section>
 <section xml:id="_authenticating_with_the_eureka_server">
@@ -177,7 +177,7 @@ This feature is not yet available on Pivotal Web Services (<link xl:href="https:
 </section>
 <section xml:id="_using_eureka_on_aws">
 <title>Using Eureka on AWS</title>
-<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
+<simpara>If the application is planned to be deployed to an AWS cloud, the Eureka instance must be configured to be AWS-aware. You can do so by customizing the <link xl:href="https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java">EurekaInstanceConfigBean</link> as follows:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Bean
 @Profile("!default")
 public EurekaInstanceConfigBean eurekaInstanceConfig(InetUtils inetUtils) {
@@ -300,7 +300,7 @@ eureka.client.preferSameZoneEureka = true</screen>
 <section xml:id="netflix-eureka-server-starter">
 <title>How to Include Eureka Server</title>
 <simpara>To include Eureka Server in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-eureka-server</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <note>
 <simpara>If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:</simpara>
 </note>
@@ -491,7 +491,7 @@ when running a Eureka server you must include these dependencies in your POM or 
 </chapter>
 <chapter xml:id="_circuit_breaker_hystrix_clients">
 <title>Circuit Breaker: Hystrix Clients</title>
-<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="http://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
+<simpara>Netflix has created a library called <link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 In a microservice architecture, it is common to have multiple layers of service calls, as shown in the following example:</simpara>
 <figure>
 <title>Microservice Graph</title>
@@ -521,7 +521,7 @@ Fallbacks may be chained so that the first fallback makes some other business ca
 <title>How to Include Hystrix</title>
 <simpara>To include Hystrix in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal>
 and a artifact ID of <literal>spring-cloud-starter-netflix-hystrix</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>The following example shows a minimal Eureka server with a Hystrix circuit breaker:</simpara>
 <screen>@SpringBootApplication
 @EnableCircuitBreaker
@@ -620,7 +620,7 @@ be slightly more than three seconds.</simpara>
 <section xml:id="netflix-hystrix-dashboard-starter">
 <title>How to Include the Hystrix Dashboard</title>
 <simpara>To include the Hystrix Dashboard in your project, use the starter with a group ID of  <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-hystrix-dashboard</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>To run the Hystrix Dashboard, annotate your Spring Boot main class with <literal>@EnableHystrixDashboard</literal>.
 Then visit <literal>/hystrix</literal> and point the dashboard to an individual instance&#8217;s <literal>/hystrix.stream</literal> endpoint in a Hystrix client application.</simpara>
 <note>
@@ -647,7 +647,7 @@ It can be overridden though with following configuration:</simpara>
       management.port: ${management.port:8081}</screen>
 <simpara>The <literal>turbine.appConfig</literal> configuration key is a list of Eureka serviceIds that turbine uses to lookup instances.
 The turbine stream is then used in the Hystrix dashboard with a URL similar to the following:</simpara>
-<simpara><literal><link xl:href="http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
+<simpara><literal><link xl:href="https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME">https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME</link></literal></simpara>
 <simpara>The cluster parameter can be omitted if the name is <literal>default</literal>.
 The <literal>cluster</literal> parameter must match an entry in <literal>turbine.aggregator.clusterConfig</literal>.
 Values returned from Eureka are upper-case. Consequently, the following example works if there is an application called <literal>customers</literal> registered with Eureka:</simpara>
@@ -716,10 +716,10 @@ You can then add the Stream binder of your choice&#8201;&#8212;&#8201;such as <l
 <simpara>Turbine Stream server also supports the <literal>cluster</literal> parameter.
 Unlike Turbine server, Turbine Stream uses eureka serviceIds as cluster names and these are not configurable.</simpara>
 <simpara>If Turbine Stream server is running on port 8989 on <literal>my.turbine.server</literal> and you have two eureka serviceIds <literal>customers</literal> and <literal>products</literal>  in your environment, the following URLs will be available on your Turbine Stream server. <literal>default</literal> and empty cluster name will provide all metrics that Turbine Stream server receives.</simpara>
-<screen>http://my.turbine.sever:8989/turbine.stream?cluster=customers
-http://my.turbine.sever:8989/turbine.stream?cluster=products
-http://my.turbine.sever:8989/turbine.stream?cluster=default
-http://my.turbine.sever:8989/turbine.stream</screen>
+<screen>https://my.turbine.sever:8989/turbine.stream?cluster=customers
+https://my.turbine.sever:8989/turbine.stream?cluster=products
+https://my.turbine.sever:8989/turbine.stream?cluster=default
+https://my.turbine.sever:8989/turbine.stream</screen>
 <simpara>So, you can use eureka serviceIds as cluster names for your Turbine dashboard (or any compatible dashboard).
 You don’t need to configure any properties like <literal>turbine.appConfig</literal>, <literal>turbine.clusterNameExpression</literal> and <literal>turbine.aggregator.clusterConfig</literal> for your Turbine Stream server.</simpara>
 <note>
@@ -739,7 +739,7 @@ This contains (amongst other things) an <literal>ILoadBalancer</literal>, a <lit
 <section xml:id="netflix-ribbon-starter">
 <title>How to Include Ribbon</title>
 <simpara>To include Ribbon in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and an artifact ID of <literal>spring-cloud-starter-netflix-ribbon</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="_customizing_the_ribbon_client">
 <title>Customizing the Ribbon Client</title>
@@ -1036,7 +1036,7 @@ If you do not put any value with <literal>LOAD_BALANCER_KEY</literal> in <litera
 <title>External Configuration: Archaius</title>
 <simpara><link xl:href="https://github.com/Netflix/archaius">Archaius</link> is the Netflix client-side configuration library.
 It is the library used by all of the Netflix OSS components for configuration.
-Archaius is an extension of the <link xl:href="http://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
+Archaius is an extension of the <link xl:href="https://commons.apache.org/proper/commons-configuration">Apache Commons Configuration</link> project.
 It allows updates to configuration by either polling a source for changes or by letting a source push changes to the client.
 Archaius uses Dynamic&lt;Type&gt;Property classes as handles to properties, as shown in the following example:</simpara>
 <formalpara>
@@ -1063,7 +1063,7 @@ This bridge allows Spring Boot projects to use the normal configuration toolchai
 <simpara>Routing is an integral part of a microservice architecture.
 For example, <literal>/</literal> may be mapped to your web application, <literal>/api/users</literal> is mapped to the user service and <literal>/api/shop</literal> is mapped to the shop service.
 <link xl:href="https://github.com/Netflix/zuul">Zuul</link> is a JVM-based router and server-side load balancer from Netflix.</simpara>
-<simpara><link xl:href="http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
+<simpara><link xl:href="https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27">Netflix uses Zuul</link> for the following:</simpara>
 <itemizedlist>
 <listitem>
 <simpara>Authentication</simpara>
@@ -1107,7 +1107,7 @@ For example, <literal>/</literal> may be mapped to your web application, <litera
 <section xml:id="netflix-zuul-starter">
 <title>How to Include Zuul</title>
 <simpara>To include Zuul in your project, use the starter with a group ID of <literal>org.springframework.cloud</literal> and a artifact ID of <literal>spring-cloud-starter-netflix-zuul</literal>.
-See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </section>
 <section xml:id="netflix-zuul-reverse-proxy">
 <title>Embedded Zuul Reverse Proxy</title>
@@ -1164,7 +1164,7 @@ The route must have a <literal>path</literal> that can be specified as an ant-st
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service</programlisting>
+      url: https://example.com/users_service</programlisting>
 </para>
 </formalpara>
 <simpara>These simple url-routes do not get executed as a <literal>HystrixCommand</literal>, nor do they load-balance multiple URLs with Ribbon.
@@ -1190,7 +1190,7 @@ hystrix:
 myusers-service:
   ribbon:
     NIWSServerListClassName: com.netflix.loadbalancer.ConfigurationBasedServerList
-    listOfServers: http://example1.com,http://example2.com
+    listOfServers: https://example1.com,http://example2.com
     ConnectTimeout: 1000
     ReadTimeout: 3000
     MaxTotalHttpConnections: 500
@@ -1417,7 +1417,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1426,7 +1426,7 @@ The Zuul proxy is a useful tool for this because you can use it to handle all tr
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com</programlisting>
+      url: https://legacy.example.com</programlisting>
 </para>
 </formalpara>
 <simpara>In the preceding example, we are strangle the <quote>legacy</quote> application, which is mapped to all requests that do not match one of the other patterns.
@@ -1664,12 +1664,12 @@ public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
         public void addCorsMappings(CorsRegistry registry) {
             registry.addMapping("/path-1/**")
-                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedOrigins("https://allowed-origin.com")
                     .allowedMethods("GET", "POST");
         }
     };
 }</programlisting>
-<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="http://allowed-origin.com">http://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
+<simpara>In the example above, we allow <literal>GET</literal> and <literal>POST</literal> methods from <literal><link xl:href="https://allowed-origin.com">https://allowed-origin.com</link></literal> to send cross-origin requests to the endpoints starting with <literal>path-1</literal>.
 You can apply CORS configuration to a specific path pattern or globally for the whole application, using <literal>/**</literal> mapping.
 You can customize properties: <literal>allowedOrigins</literal>,<literal>allowedMethods</literal>,<literal>allowedHeaders</literal>,<literal>exposedHeaders</literal>,<literal>allowCredentials</literal> and <literal>maxAge</literal> via this configuration.</simpara>
 </section>
@@ -2044,7 +2044,7 @@ The non-JVM application can access the customer service at <literal><link xl:hre
 <simpara>If the Config Server is registered with Eureka, the non-JVM application can access it through the Zuul proxy.
 If the <literal>serviceId</literal> of the ConfigServer is <literal>configserver</literal> and the Sidecar is on port 5678, then it can be accessed at <link xl:href="http://localhost:5678/configserver">http://localhost:5678/configserver</link>.</simpara>
 <simpara>Non-JVM applications can take advantage of the Config Server&#8217;s ability to return YAML documents.
-For example, a call to <link xl:href="http://sidecar.local.spring.io:5678/configserver/default-master.yml">http://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
+For example, a call to <link xl:href="https://sidecar.local.spring.io:5678/configserver/default-master.yml">https://sidecar.local.spring.io:5678/configserver/default-master.yml</link>
 might result in a YAML document resembling the following:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">eureka:
   client:

--- a/spring-cloud-openfeign/2.0.0.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.0.0.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.0.1.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.0.1.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.0.2.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.0.2.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.0.3.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.0.3.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.M1/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.M1/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.M2/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.M2/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.RC1/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.RC1/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.RC2/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.RC2/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.RC3/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.RC3/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.0.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.0.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-openfeign/2.1.1.RELEASE/spring-cloud-openfeign.xml
+++ b/spring-cloud-openfeign/2.1.1.RELEASE/spring-cloud-openfeign.xml
@@ -18,7 +18,7 @@ and binding to the Spring Environment and other Spring programming model idioms.
 <section xml:id="netflix-feign-starter">
 <title>How to Include Feign</title>
 <simpara>To include Feign in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-openfeign</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>Example spring boot app</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication

--- a/spring-cloud-security/1.2.2.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/1.2.2.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/1.2.3.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/1.2.3.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.0.0.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/2.0.0.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.0.1.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/2.0.1.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.0.M1/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.0.M1/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.0.RC1/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.0.RC1/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.0.RC2/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.0.RC2/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.0.RC3/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.0.RC3/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -226,7 +226,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.0.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.0.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -226,7 +226,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/2.1.2.RELEASE/spring-cloud-security.xml
+++ b/spring-cloud-security/2.1.2.RELEASE/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -226,7 +226,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-sleuth/1.2.5.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.2.5.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1391,7 +1391,7 @@ Stream based span reporting).</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1483,7 +1483,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1672,7 +1672,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1766,7 +1766,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1787,10 +1787,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.2.6.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.2.6.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1391,7 +1391,7 @@ Stream based span reporting).</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1484,7 +1484,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1673,7 +1673,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1772,7 +1772,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1793,10 +1793,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.0.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.0.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1294,7 +1294,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -1302,7 +1302,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1394,7 +1394,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1583,7 +1583,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1685,7 +1685,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1706,10 +1706,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.1.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.1.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1294,7 +1294,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -1302,7 +1302,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1395,7 +1395,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1584,7 +1584,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1686,7 +1686,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1707,10 +1707,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.2.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.2.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1295,7 +1295,7 @@ Stream based span reporting).</simpara>
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -1303,7 +1303,7 @@ Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</lit
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1396,7 +1396,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1585,7 +1585,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1687,7 +1687,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1708,10 +1708,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.3.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.3.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1300,7 +1300,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL (example for <literal>zipkinserver</literal> service id)</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
@@ -1313,7 +1313,7 @@ Example for <literal>web</literal>:</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1412,7 +1412,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1601,7 +1601,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1703,7 +1703,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1752,10 +1752,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.4.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.4.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1302,7 +1302,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL. If you want to disable this feature
 just set <literal>spring.zipkin.discoveryClientEnabled</literal> to <literal>false.
@@ -1344,7 +1344,7 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1443,7 +1443,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1632,7 +1632,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1734,7 +1734,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1783,10 +1783,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/1.3.5.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/1.3.5.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1309,7 +1309,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL. If you want to disable this feature
 just set <literal>spring.zipkin.discoveryClientEnabled</literal> to <literal>false.
@@ -1351,7 +1351,7 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1450,7 +1450,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1639,7 +1639,7 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
@@ -1741,7 +1741,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1790,10 +1790,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/spring-cloud-sleuth/2.0.0.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.0.0.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -691,7 +691,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -807,7 +807,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1543,7 +1543,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1586,13 +1586,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1785,7 +1785,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -1906,7 +1906,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -1946,11 +1946,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.0.1.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.0.1.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -695,7 +695,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -811,7 +811,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/sleuth/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1547,7 +1547,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1590,13 +1590,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1789,7 +1789,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -1910,7 +1910,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -1950,11 +1950,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.0.2.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.0.2.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -695,7 +695,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -822,7 +822,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1576,7 +1576,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1619,13 +1619,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1824,7 +1824,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -1945,7 +1945,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -1985,11 +1985,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.0.3.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.0.3.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -695,7 +695,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -822,7 +822,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1576,7 +1576,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1619,13 +1619,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1824,7 +1824,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -1945,7 +1945,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -1985,11 +1985,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.0.M2/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.0.M2/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -694,7 +694,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -821,7 +821,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1607,7 +1607,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1650,13 +1650,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1858,7 +1858,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -1985,7 +1985,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2040,11 +2040,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.0.RC1/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.0.RC1/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -694,7 +694,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -821,7 +821,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1607,7 +1607,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1650,13 +1650,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1858,7 +1858,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -2019,7 +2019,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2074,11 +2074,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.0.RC2/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.0.RC2/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -694,7 +694,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -821,7 +821,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1607,7 +1607,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1650,13 +1650,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1858,7 +1858,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -2019,7 +2019,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2074,11 +2074,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.0.RC3/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.0.RC3/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -693,7 +693,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -820,7 +820,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1608,7 +1608,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1651,13 +1651,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1860,7 +1860,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -2028,7 +2028,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2083,11 +2083,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.0.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.0.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -745,7 +745,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -872,7 +872,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1661,7 +1661,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1704,13 +1704,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1913,7 +1913,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -2081,7 +2081,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2136,11 +2136,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-sleuth/2.1.1.RELEASE/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth/2.1.1.RELEASE/spring-cloud-sleuth.xml
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -745,7 +745,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -872,7 +872,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1662,7 +1662,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1705,13 +1705,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1917,7 +1917,7 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
@@ -2092,7 +2092,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2147,11 +2147,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.0.RC1/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.0.RC1/spring-cloud-stream-binder-kafka.xml
@@ -39,7 +39,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -470,12 +470,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -848,7 +848,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -858,13 +858,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -916,7 +916,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -943,7 +943,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.0.RC2/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.0.RC2/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -473,12 +473,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -883,7 +883,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1474,7 +1474,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1484,13 +1484,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1542,7 +1542,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1569,7 +1569,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.0.RC3/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.0.RC3/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -473,12 +473,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -883,7 +883,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1474,7 +1474,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1484,13 +1484,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1542,7 +1542,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1569,7 +1569,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.0.RC4/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.0.RC4/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -473,12 +473,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -883,7 +883,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1474,7 +1474,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1484,13 +1484,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1542,7 +1542,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1569,7 +1569,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.0.RELEASE/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.0.RELEASE/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -473,12 +473,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -883,7 +883,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1474,7 +1474,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1484,13 +1484,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1542,7 +1542,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1569,7 +1569,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.1.RELEASE/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.1.RELEASE/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -519,12 +519,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -929,7 +929,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1520,7 +1520,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1530,13 +1530,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1588,7 +1588,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1615,7 +1615,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-kafka/2.1.2.RELEASE/spring-cloud-stream-binder-kafka.xml
+++ b/spring-cloud-stream-binder-kafka/2.1.2.RELEASE/spring-cloud-stream-binder-kafka.xml
@@ -41,7 +41,7 @@ In addition, this guide explains the Kafka Streams binding capabilities of Sprin
 <title>Kafka Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>kafka binder</phrase></textobject>
 </mediaobject>
@@ -519,12 +519,12 @@ public class ManuallyAcknowdledgingConsumer {
 <section xml:id="_example_security_configuration">
 <title>Example: Security Configuration</title>
 <simpara>Apache Kafka 0.9 supports secure connections between client and brokers.
-To take advantage of this feature, follow the guidelines in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="http://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
+To take advantage of this feature, follow the guidelines in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_configclients">Apache Kafka Documentation</link> as well as the Kafka 0.9 <link xl:href="https://docs.confluent.io/2.0.0/kafka/security.html">security guidelines from the Confluent documentation</link>.
 Use the <literal>spring.cloud.stream.kafka.binder.configuration</literal> option to set security properties for all clients created by the binder.</simpara>
 <simpara>For example, to set <literal>security.protocol</literal> to <literal>SASL_SSL</literal>, set the following property:</simpara>
 <screen>spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL</screen>
 <simpara>All the other security properties can be set in a similar manner.</simpara>
-<simpara>When using Kerberos, follow the instructions in the <link xl:href="http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
+<simpara>When using Kerberos, follow the instructions in the <link xl:href="https://kafka.apache.org/090/documentation.html#security_sasl_clientconfig">reference documentation</link> for creating and referencing the JAAS configuration.</simpara>
 <simpara>Spring Cloud Stream supports passing JAAS configuration information to the application by using a JAAS configuration file and using Spring Boot properties.</simpara>
 <section xml:id="_using_jaas_configuration_files">
 <title>Using JAAS Configuration Files</title>
@@ -929,7 +929,7 @@ Maven coordinates:</simpara>
 <simpara>Spring Cloud Stream&#8217;s Apache Kafka support also includes a binder implementation designed explicitly for Apache Kafka
 Streams binding. With this native integration, a Spring Cloud Stream "processor" application can directly use the
 <link xl:href="https://kafka.apache.org/documentation/streams/developer-guide">Apache Kafka Streams</link> APIs in the core business logic.</simpara>
-<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
+<simpara>Kafka Streams binder implementation builds on the foundation provided by the <link xl:href="https://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams">Kafka Streams in Spring Kafka</link>
 project.</simpara>
 <simpara>Kafka Streams binder provides binding capabilities for the three major types in Kafka Streams - KStream, KTable and GlobalKTable.</simpara>
 <simpara>As part of this native integration, the high-level <link xl:href="https://docs.confluent.io/current/streams/developer-guide/dsl-api.html">Streams DSL</link>
@@ -1520,7 +1520,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1530,13 +1530,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1588,7 +1588,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1615,7 +1615,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.0.RC1/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.0.RC1/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1370,7 +1370,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1380,13 +1380,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1439,7 +1439,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1466,7 +1466,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.0.RC2/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.0.RC2/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1370,7 +1370,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1380,13 +1380,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1439,7 +1439,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1466,7 +1466,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.0.RC3/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.0.RC3/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1370,7 +1370,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1380,13 +1380,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1439,7 +1439,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1466,7 +1466,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.0.RC4/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.0.RC4/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1370,7 +1370,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1380,13 +1380,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1439,7 +1439,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1466,7 +1466,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.0.RELEASE/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.0.RELEASE/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1370,7 +1370,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1380,13 +1380,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1439,7 +1439,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1466,7 +1466,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.1.RELEASE/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.1.RELEASE/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1381,7 +1381,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1391,13 +1391,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1450,7 +1450,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1477,7 +1477,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream-binder-rabbit/2.1.2.RELEASE/spring-cloud-stream-binder-rabbit.xml
+++ b/spring-cloud-stream-binder-rabbit/2.1.2.RELEASE/spring-cloud-stream-binder-rabbit.xml
@@ -38,7 +38,7 @@ It contains information about its design, usage and configuration options, as we
 <title>RabbitMQ Binder</title>
 <mediaobject>
 <imageobject>
-<imagedata fileref="http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
+<imagedata fileref="https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png" width="50%"/>
 </imageobject>
 <textobject><phrase>rabbit binder</phrase></textobject>
 </mediaobject>
@@ -85,7 +85,7 @@ You can exclude the class by using the <literal>@SpringBootApplication</literal>
 <title>RabbitMQ Binder Properties</title>
 <simpara>By default, the RabbitMQ binder uses Spring Boot&#8217;s <literal>ConnectionFactory</literal>.
 Conseuqently, it supports all Spring Boot configuration options for RabbitMQ.
-(For reference, see the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
+(For reference, see the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties">Spring Boot documentation</link>).
 RabbitMQ configuration options use the <literal>spring.rabbitmq</literal> prefix.</simpara>
 <simpara>In addition to Spring Boot options, the RabbitMQ binder supports the following properties:</simpara>
 <variablelist>
@@ -1381,7 +1381,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xl:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xl:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers.</simpara>
 </section>
 <section xml:id="_documentation">
@@ -1391,13 +1391,13 @@ in Docker containers.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xl:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xl:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xl:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xl:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xl:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xl:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -1450,7 +1450,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xl:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xl:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xl:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -1477,7 +1477,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xl:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xl:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream/2.1.0.M4/index.xml
+++ b/spring-cloud-stream/2.1.0.M4/index.xml
@@ -134,7 +134,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_spring_s_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xlink:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xlink:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xlink:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xlink:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xlink:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -787,7 +787,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xlink:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xlink:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xlink:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2362,7 +2362,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xlink:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xlink:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2886,7 +2886,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xlink:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xlink:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xlink:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 </part>
@@ -2920,7 +2920,7 @@ source control.</simpara>
 </note>
 <simpara>The projects that require middleware generally include a
 <literal>docker-compose.yml</literal>, so consider using
-<link xlink:href="http://compose.docker.io/">Docker Compose</link> to run the middeware servers
+<link xlink:href="https://compose.docker.io/">Docker Compose</link> to run the middeware servers
 in Docker containers. See the README in the
 <link xlink:href="https://github.com/spring-cloud-samples/scripts">scripts demo
 repository</link> for specific instructions about the common cases of mongo,
@@ -2933,13 +2933,13 @@ rabbit and redis.</simpara>
 <section xml:id="_working_with_the_code">
 <title>Working with the code</title>
 <simpara>If you don&#8217;t have an IDE preference we would recommend that you use
-<link xlink:href="http://www.springsource.com/developer/sts">Spring Tools Suite</link> or
-<link xlink:href="http://eclipse.org">Eclipse</link> when working with the code. We use the
-<link xlink:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
+<link xlink:href="https://www.springsource.com/developer/sts">Spring Tools Suite</link> or
+<link xlink:href="https://eclipse.org">Eclipse</link> when working with the code. We use the
+<link xlink:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.</simpara>
 <section xml:id="_importing_into_eclipse_with_m2eclipse">
 <title>Importing into eclipse with m2eclipse</title>
-<simpara>We recommend the <link xlink:href="http://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
+<simpara>We recommend the <link xlink:href="https://eclipse.org/m2e/">m2eclipe</link> eclipse plugin when working with
 eclipse. If you don&#8217;t already have m2eclipse installed it is available from the "eclipse
 marketplace".</simpara>
 <simpara>Unfortunately m2e does not yet support Maven 3.3, so once the projects
@@ -2991,7 +2991,7 @@ you can import formatter settings using the
 <literal>eclipse-code-formatter.xml</literal> file from the
 <link xlink:href="https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml">Spring
 Cloud Build</link> project. If using IntelliJ, you can use the
-<link xlink:href="http://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
+<link xlink:href="https://plugins.jetbrains.com/plugin/6546">Eclipse Code Formatter
 Plugin</link> to import the same file.</simpara>
 </listitem>
 <listitem>
@@ -3018,7 +3018,7 @@ than cosmetic changes).</simpara>
 other target branch in the main project).</simpara>
 </listitem>
 <listitem>
-<simpara>When writing a commit message please follow <link xlink:href="http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
+<simpara>When writing a commit message please follow <link xlink:href="https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html">these conventions</link>,
 if you are fixing an existing issue please add <literal>Fixes gh-XXXX</literal> at the end of the commit
 message (where XXXX is the issue number).</simpara>
 </listitem>

--- a/spring-cloud-stream/2.1.0.RC1/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.0.RC1/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -767,7 +767,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2342,7 +2342,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2866,7 +2866,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/2.1.0.RC3/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.0.RC3/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -769,7 +769,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2345,7 +2345,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2869,7 +2869,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/2.1.0.RC4/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.0.RC4/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -769,7 +769,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2345,7 +2345,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2869,7 +2869,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/2.1.0.RELEASE/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.0.RELEASE/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -709,7 +709,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2295,7 +2295,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2981,7 +2981,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/2.1.1.RELEASE/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.1.RELEASE/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -709,7 +709,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2314,7 +2314,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -3000,7 +3000,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/2.1.2.RELEASE/spring-cloud-stream.xml
+++ b/spring-cloud-stream/2.1.2.RELEASE/spring-cloud-stream.xml
@@ -126,7 +126,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -715,7 +715,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2329,7 +2329,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -3023,7 +3023,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/Fishtown.RC1/spring-cloud-stream.xml
+++ b/spring-cloud-stream/Fishtown.RC1/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -767,7 +767,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2342,7 +2342,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2866,7 +2866,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-stream/Fishtown.RC2/spring-cloud-stream.xml
+++ b/spring-cloud-stream/Fishtown.RC2/spring-cloud-stream.xml
@@ -120,7 +120,7 @@
 <title>Preface</title>
 <chapter xml:id="_a_brief_history_of_springs_data_integration_journey">
 <title>A Brief History of Spring&#8217;s Data Integration Journey</title>
-<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
+<simpara>Spring&#8217;s journey on Data Integration started with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. With its programming model, it provided a consistent developer experience to build applications that can embrace <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> to connect with external systems such as, databases, message brokers, and among others.</simpara>
 <simpara>Fast forward to the cloud-era, where microservices have become prominent in the enterprise setting. <link xl:href="https://projects.spring.io/spring-boot/">Spring Boot</link> transformed the way how developers built Applications. With Spring&#8217;s programming model and the runtime responsibilities handled by Spring Boot, it became seamless to develop stand-alone, production-grade Spring-based microservices.</simpara>
 <simpara>To extend this to Data Integration workloads, Spring Integration and Spring Boot were put together into a new project. Spring Cloud Stream was born.</simpara>
 <simpara>With Spring Cloud Stream, developers can:
@@ -769,7 +769,7 @@ private MessageChannel output;</programlisting>
 <simpara>You can write a Spring Cloud Stream application by using either Spring Integration annotations or Spring Cloud Stream native annotation.</simpara>
 <section xml:id="_spring_integration_support">
 <title>Spring Integration Support</title>
-<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="http://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
+<simpara>Spring Cloud Stream is built on the concepts and patterns defined by <link xl:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration Patterns</link> and relies
 in its internal implementation on an already established and popular implementation of Enterprise Integration Patterns within the Spring portfolio of projects:
 <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link> framework.</simpara>
 <simpara>So its only natural for it to support the foundation, semantics, and configuration options that are already established by Spring Integration</simpara>
@@ -2344,7 +2344,7 @@ The <literal>spring.cloud.stream.schema.server.path</literal> property can be us
 The <literal>spring.cloud.stream.schema.server.allowSchemaDeletion</literal> boolean property enables the deletion of a schema. By default, this is disabled.</simpara>
 <simpara>The schema registry server uses a relational database to store the schemas.
 By default, it uses an embedded database.
-You can customize the schema storage by using the <link xl:href="http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
+You can customize the schema storage by using the <link xl:href="https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql">Spring Boot SQL database and JDBC configuration options</link>.</simpara>
 <simpara>The following example shows a Spring Boot application that enables the schema registry:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@SpringBootApplication
 @EnableSchemaRegistryServer
@@ -2868,7 +2868,7 @@ a <literal>STREAM_CLOUD_STREAM_VERSION</literal> header set to <literal>2.x</lit
 <section xml:id="_deploying_stream_applications_on_cloudfoundry">
 <title>Deploying Stream Applications on CloudFoundry</title>
 <simpara>On CloudFoundry, services are usually exposed through a special environment variable called <link xl:href="https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES">VCAP_SERVICES</link>.</simpara>
-<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
+<simpara>When configuring your binder connections, you can use the values from an environment variable as explained on the <link xl:href="https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups">dataflow Cloud Foundry Server</link> docs.</simpara>
 </section>
 </chapter>
 <chapter xml:id="_binder_implementations">

--- a/spring-cloud-vault/1.1.1.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/1.1.1.RELEASE/spring-cloud-vault.xml
@@ -183,8 +183,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -192,7 +192,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/1.1.2.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/1.1.2.RELEASE/spring-cloud-vault.xml
@@ -183,8 +183,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -192,7 +192,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.0.0.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.0.0.RELEASE/spring-cloud-vault.xml
@@ -183,8 +183,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -192,7 +192,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.0.1.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.0.1.RELEASE/spring-cloud-vault.xml
@@ -183,8 +183,8 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the
@@ -192,7 +192,7 @@ property <literal>health.vault.enabled</literal> (default <literal>true</literal
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.0.2.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.0.2.RELEASE/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.0.3.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.0.3.RELEASE/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.1.0.M1/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.1.0.M1/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.1.0.M2/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.1.0.M2/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.1.0.RC1/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.1.0.RC1/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.1.0.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.1.0.RELEASE/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-vault/2.1.1.RELEASE/spring-cloud-vault.xml
+++ b/spring-cloud-vault/2.1.1.RELEASE/spring-cloud-vault.xml
@@ -183,15 +183,15 @@ Supported schemes are <literal>http</literal> and <literal>https</literal>.</sim
 <simpara>Enabling further integrations requires additional dependencies and
 configuration. Depending on how you have set up Vault you might need
 additional configuration like
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
-<link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.ssl">SSL</link> and
+<link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication</link>.</simpara>
 <simpara>If the application imports the <literal>spring-boot-starter-actuator</literal> project, the
 status of the vault server will be available via the <literal>/health</literal> endpoint.</simpara>
 <simpara>The vault health indicator can be enabled or disabled through the property <literal>management.health.vault.enabled</literal> (default to <literal>true</literal>).</simpara>
 <section xml:id="_authentication">
 <title>Authentication</title>
 <simpara>Vault requires an <link xl:href="https://www.vaultproject.io/docs/concepts/auth.html">authentication mechanism</link> to <link xl:href="https://www.vaultproject.io/docs/concepts/tokens.html">authorize client requests</link>.</simpara>
-<simpara>Spring Cloud Vault supports multiple <link xl:href="http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
+<simpara>Spring Cloud Vault supports multiple <link xl:href="https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html#vault.config.authentication">authentication mechanisms</link> to authenticate applications with Vault.</simpara>
 <simpara>For a quickstart, use the root token printed by the <link linkend="quickstart.vault.start">Vault initialization</link>.</simpara>
 <example>
 <title>bootstrap.yml</title>

--- a/spring-cloud-zookeeper/1.1.3.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/1.1.3.RELEASE/spring-cloud-zookeeper.xml
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/spring-cloud-zookeeper/1.2.0.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/1.2.0.RELEASE/spring-cloud-zookeeper.xml
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/spring-cloud-zookeeper/1.2.1.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/1.2.1.RELEASE/spring-cloud-zookeeper.xml
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/spring-cloud-zookeeper/1.2.2.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/1.2.2.RELEASE/spring-cloud-zookeeper.xml
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/spring-cloud-zookeeper/2.0.0.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.0.0.RELEASE/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.0.1.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.0.1.RELEASE/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.1.0.M1/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.1.0.M1/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.1.0.RC1/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.1.0.RC1/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.1.0.RC2/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.1.0.RC2/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.1.0.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.1.0.RELEASE/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.

--- a/spring-cloud-zookeeper/2.1.1.RELEASE/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper/2.1.1.RELEASE/spring-cloud-zookeeper.xml
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://codearte.io (200) with 35 occurrences could not be migrated:  
   ([https](https://codearte.io) result SSLHandshakeException).
* [ ] http://dubbo.io/ (200) with 18 occurrences could not be migrated:  
   ([https](https://dubbo.io/) result SSLHandshakeException).
* [ ] http://groovy-lang.org/json.html (200) with 102 occurrences could not be migrated:  
   ([https](https://groovy-lang.org/json.html) result SSLProtocolException).
* [ ] http://httpbin.org:80 (200) with 60 occurrences could not be migrated:  
   ([https](https://httpbin.org:80) result NotSslRecordException).
* [ ] http://myconfigserver.com (200) with 45 occurrences could not be migrated:  
   ([https](https://myconfigserver.com) result ConnectTimeoutException).
* [ ] http://partners.com (200) with 103 occurrences could not be migrated:  
   ([https](https://partners.com) result SSLHandshakeException).
* [ ] http://reactivex.io/ (200) with 15 occurrences could not be migrated:  
   ([https](https://reactivex.io/) result SSLHandshakeException).
* [ ] http://rest-assured.io/ (200) with 35 occurrences could not be migrated:  
   ([https](https://rest-assured.io/) result SSLHandshakeException).
* [ ] http://spockframework.org/ (200) with 12 occurrences could not be migrated:  
   ([https](https://spockframework.org/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/accurest/ (200) with 35 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/accurest/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/spring-cloud-contract/ (200) with 35 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/spring-cloud-contract/) result SSLHandshakeException).
* [ ] http://wiremock.org (200) with 62 occurrences could not be migrated:  
   ([https](https://wiremock.org) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/stateful-behaviour/ (200) with 30 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/stateful-behaviour/) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/stubbing/ (200) with 32 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/stubbing/) result SSLHandshakeException).
* [ ] http://wiremock.org/stateful-behaviour.html (200) with 40 occurrences could not be migrated:  
   ([https](https://wiremock.org/stateful-behaviour.html) result SSLHandshakeException).
* [ ] http://wiremock.org/stubbing.html (200) with 35 occurrences could not be migrated:  
   ([https](https://wiremock.org/stubbing.html) result SSLHandshakeException).
* [ ] http://192.168.0.100:8081/artifactory/libs-release-local (403) with 54 occurrences could not be migrated:  
   ([https](https://192.168.0.100:8081/artifactory/libs-release-local) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://bugreport.sun.com/bugreport/ (302) with 2 occurrences migrated to:  
  https://bugreport.java.com/bugreport/ ([https](https://bugreport.sun.com/bugreport/) result SSLHandshakeException).
* [ ] http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 (AnnotatedConnectException) with 16 occurrences migrated to:  
  https://169.254.169.254/latest/dynamic/instance-identity/pkcs7 ([https](https://169.254.169.254/latest/dynamic/instance-identity/pkcs7) result ConnectTimeoutException).
* [ ] http://192.168.99.100:9411/ (ConnectTimeoutException) with 30 occurrences migrated to:  
  https://192.168.99.100:9411/ ([https](https://192.168.99.100:9411/) result ConnectTimeoutException).
* [ ] http://acme.org (ConnectTimeoutException) with 40 occurrences migrated to:  
  https://acme.org ([https](https://acme.org) result ConnectTimeoutException).
* [ ] http://allowed-origin.com (UnknownHostException) with 36 occurrences migrated to:  
  https://allowed-origin.com ([https](https://allowed-origin.com) result UnknownHostException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 26 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/ (UnknownHostException) with 20 occurrences migrated to:  
  https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/ ([https](https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/) result UnknownHostException).
* [ ] http://example1.com,http://example2.com (UnknownHostException) with 32 occurrences migrated to:  
  https://example1.com,http://example2.com ([https](https://example1.com,https://example2.com) result UnknownHostException).
* [ ] http://first.example.com (UnknownHostException) with 35 occurrences migrated to:  
  https://first.example.com ([https](https://first.example.com) result UnknownHostException).
* [ ] http://foo.bar (UnknownHostException) with 35 occurrences migrated to:  
  https://foo.bar ([https](https://foo.bar) result UnknownHostException).
* [ ] http://git/team-a/config-repo.git (UnknownHostException) with 180 occurrences migrated to:  
  https://git/team-a/config-repo.git ([https](https://git/team-a/config-repo.git) result UnknownHostException).
* [ ] http://git/team-b/config-repo.git (UnknownHostException) with 90 occurrences migrated to:  
  https://git/team-b/config-repo.git ([https](https://git/team-b/config-repo.git) result UnknownHostException).
* [ ] http://legacy.example.com (UnknownHostException) with 35 occurrences migrated to:  
  https://legacy.example.com ([https](https://legacy.example.com) result UnknownHostException).
* [ ] http://my.endpoint/push (UnknownHostException) with 8 occurrences migrated to:  
  https://my.endpoint/push ([https](https://my.endpoint/push) result UnknownHostException).
* [ ] http://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME (UnknownHostException) with 40 occurrences migrated to:  
  https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME ([https](https://my.turbine.server:8080/turbine.stream?cluster=CLUSTERNAME) result UnknownHostException).
* [ ] http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME (UnknownHostException) with 30 occurrences migrated to:  
  https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME ([https](https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME) result UnknownHostException).
* [ ] http://my.turbine.sever:8989/turbine.stream (UnknownHostException) with 22 occurrences migrated to:  
  https://my.turbine.sever:8989/turbine.stream ([https](https://my.turbine.sever:8989/turbine.stream) result UnknownHostException).
* [ ] http://my.turbine.sever:8989/turbine.stream?cluster=customers (UnknownHostException) with 22 occurrences migrated to:  
  https://my.turbine.sever:8989/turbine.stream?cluster=customers ([https](https://my.turbine.sever:8989/turbine.stream?cluster=customers) result UnknownHostException).
* [ ] http://my.turbine.sever:8989/turbine.stream?cluster=default (UnknownHostException) with 22 occurrences migrated to:  
  https://my.turbine.sever:8989/turbine.stream?cluster=default ([https](https://my.turbine.sever:8989/turbine.stream?cluster=default) result UnknownHostException).
* [ ] http://my.turbine.sever:8989/turbine.stream?cluster=products (UnknownHostException) with 22 occurrences migrated to:  
  https://my.turbine.sever:8989/turbine.stream?cluster=products ([https](https://my.turbine.sever:8989/turbine.stream?cluster=products) result UnknownHostException).
* [ ] http://myapp.host.com/actuator/refresh (UnknownHostException) with 8 occurrences migrated to:  
  https://myapp.host.com/actuator/refresh ([https](https://myapp.host.com/actuator/refresh) result UnknownHostException).
* [ ] http://sidecar.local.spring.io:5678/configserver/default-master.yml (UnknownHostException) with 70 occurrences migrated to:  
  https://sidecar.local.spring.io:5678/configserver/default-master.yml ([https](https://sidecar.local.spring.io:5678/configserver/default-master.yml) result UnknownHostException).
* [ ] http://www.uri-destination.org (UnknownHostException) with 10 occurrences migrated to:  
  https://www.uri-destination.org ([https](https://www.uri-destination.org) result UnknownHostException).
* [ ] http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html (404) with 18 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html ([https](https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html) result 404).
* [ ] http://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html (404) with 8 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud-static/docs/1.0.x/spring-cloud.html) result 404).
* [ ] http://cloud.spring.io/spring-cloud.html (404) with 25 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud.html) result 404).
* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 24 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).
* [ ] http://docs.spring.io/spring-kafka/reference/html/_reference.html (301) with 20 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/reference/html/_reference.html ([https](https://docs.spring.io/spring-kafka/reference/html/_reference.html) result 404).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html (301) with 20 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html) result 404).
* [ ] http://docsbrewing-zipkin-web.cfapps.io/ (404) with 3 occurrences migrated to:  
  https://docsbrewing-zipkin-web.cfapps.io/ ([https](https://docsbrewing-zipkin-web.cfapps.io/) result 404).
* [ ] http://docssleuth-zipkin-server.cfapps.io/dependency (404) with 18 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/dependency ([https](https://docssleuth-zipkin-server.cfapps.io/dependency) result 404).
* [ ] http://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html (404) with 3 occurrences migrated to:  
  https://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html ([https](https://download.eclipse.org/aether/aether-core/0.9.0/apidocs/org/eclipse/aether/util/version/GenericVersionScheme.html) result 404).
* [ ] http://example.com/users_service (404) with 35 occurrences migrated to:  
  https://example.com/users_service ([https](https://example.com/users_service) result 404).
* [ ] http://repo.spring.io/milestone/&lt;/url&gt (404) with 8 occurrences migrated to:  
  https://repo.spring.io/milestone/&lt;/url&gt ([https](https://repo.spring.io/milestone/&lt;/url&gt) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-logging/1.5.14.RELEASE/spring-boot-starter-logging-1.5.14.RELEASE-javadoc.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-logging/1.5.14.RELEASE/spring-boot-starter-logging-1.5.14.RELEASE-javadoc.jar ([https](https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-logging/1.5.14.RELEASE/spring-boot-starter-logging-1.5.14.RELEASE-javadoc.jar) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-tomcat/1.5.14.RELEASE/spring-boot-starter-tomcat-1.5.14.RELEASE-javadoc.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-tomcat/1.5.14.RELEASE/spring-boot-starter-tomcat-1.5.14.RELEASE-javadoc.jar ([https](https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-tomcat/1.5.14.RELEASE/spring-boot-starter-tomcat-1.5.14.RELEASE-javadoc.jar) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-web/1.5.14.RELEASE/spring-boot-starter-web-1.5.14.RELEASE-javadoc.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-web/1.5.14.RELEASE/spring-boot-starter-web-1.5.14.RELEASE-javadoc.jar ([https](https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-web/1.5.14.RELEASE/spring-boot-starter-web-1.5.14.RELEASE-javadoc.jar) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter/1.5.14.RELEASE/spring-boot-starter-1.5.14.RELEASE-javadoc.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter/1.5.14.RELEASE/spring-boot-starter-1.5.14.RELEASE-javadoc.jar ([https](https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter/1.5.14.RELEASE/spring-boot-starter-1.5.14.RELEASE-javadoc.jar) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway-dependencies/1.0.2.RELEASE/spring-cloud-gateway-dependencies-1.0.2.RELEASE.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway-dependencies/1.0.2.RELEASE/spring-cloud-gateway-dependencies-1.0.2.RELEASE.jar ([https](https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway-dependencies/1.0.2.RELEASE/spring-cloud-gateway-dependencies-1.0.2.RELEASE.jar) result 404).
* [ ] http://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway/1.0.2.RELEASE/spring-cloud-gateway-1.0.2.RELEASE.jar (404) with 14 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway/1.0.2.RELEASE/spring-cloud-gateway-1.0.2.RELEASE.jar ([https](https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-gateway/1.0.2.RELEASE/spring-cloud-gateway-1.0.2.RELEASE.jar) result 404).
* [ ] http://repo.spring.io/release/&lt;/url&gt (404) with 8 occurrences migrated to:  
  https://repo.spring.io/release/&lt;/url&gt ([https](https://repo.spring.io/release/&lt;/url&gt) result 404).
* [ ] http://repo.spring.io/snapshots (404) with 35 occurrences migrated to:  
  https://repo.spring.io/snapshots ([https](https://repo.spring.io/snapshots) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 3 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd ([https](https://www.springframework.org/schema/cloud/aws/cache/spring-cloud-aws-cache.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd (404) with 32 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd ([https](https://www.springframework.org/schema/cloud/aws/context/spring-cloud-aws-context.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd ([https](https://www.springframework.org/schema/cloud/aws/jdbc/spring-cloud-aws-jdbc.xsd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd ([https](https://www.springframework.org/schema/cloud/aws/mail/spring-cloud-aws-mail.xsd) result 404).
* [ ] http://zipkin.io/pages/existing_instrumentations.html (301) with 18 occurrences migrated to:  
  https://zipkin.io/pages/existing_instrumentations.html ([https](https://zipkin.io/pages/existing_instrumentations.html) result 404).
* [ ] http://api.twitter.com/1/geo/id/01fbe706f872cb32.json (403) with 24 occurrences migrated to:  
  https://api.twitter.com/1/geo/id/01fbe706f872cb32.json ([https](https://api.twitter.com/1/geo/id/01fbe706f872cb32.json) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://12factor.net/ with 33 occurrences migrated to:  
  https://12factor.net/ ([https](https://12factor.net/) result 200).
* [ ] http://aws.amazon.com with 8 occurrences migrated to:  
  https://aws.amazon.com ([https](https://aws.amazon.com) result 200).
* [ ] http://aws.amazon.com/cloudformation/ with 16 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/ ([https](https://aws.amazon.com/cloudformation/) result 200).
* [ ] http://aws.amazon.com/cloudformation/aws-cloudformation-templates/ with 8 occurrences migrated to:  
  https://aws.amazon.com/cloudformation/aws-cloudformation-templates/ ([https](https://aws.amazon.com/cloudformation/aws-cloudformation-templates/) result 200).
* [ ] http://aws.amazon.com/de/ses/ with 8 occurrences migrated to:  
  https://aws.amazon.com/de/ses/ ([https](https://aws.amazon.com/de/ses/) result 200).
* [ ] http://aws.amazon.com/ec2/ with 8 occurrences migrated to:  
  https://aws.amazon.com/ec2/ ([https](https://aws.amazon.com/ec2/) result 200).
* [ ] http://aws.amazon.com/elasticache/ with 16 occurrences migrated to:  
  https://aws.amazon.com/elasticache/ ([https](https://aws.amazon.com/elasticache/) result 200).
* [ ] http://aws.amazon.com/rds/ with 16 occurrences migrated to:  
  https://aws.amazon.com/rds/ ([https](https://aws.amazon.com/rds/) result 200).
* [ ] http://aws.amazon.com/s3/ with 16 occurrences migrated to:  
  https://aws.amazon.com/s3/ ([https](https://aws.amazon.com/s3/) result 200).
* [ ] http://aws.amazon.com/sdk-for-java/ with 8 occurrences migrated to:  
  https://aws.amazon.com/sdk-for-java/ ([https](https://aws.amazon.com/sdk-for-java/) result 200).
* [ ] http://aws.amazon.com/ses/ with 8 occurrences migrated to:  
  https://aws.amazon.com/ses/ ([https](https://aws.amazon.com/ses/) result 200).
* [ ] http://aws.amazon.com/sns/ with 8 occurrences migrated to:  
  https://aws.amazon.com/sns/ ([https](https://aws.amazon.com/sns/) result 200).
* [ ] http://aws.amazon.com/sqs/ with 24 occurrences migrated to:  
  https://aws.amazon.com/sqs/ ([https](https://aws.amazon.com/sqs/) result 200).
* [ ] http://cloud.google.com/datastore/ with 8 occurrences migrated to:  
  https://cloud.google.com/datastore/ ([https](https://cloud.google.com/datastore/) result 200).
* [ ] http://cloud.google.com/spanner/ with 8 occurrences migrated to:  
  https://cloud.google.com/spanner/ ([https](https://cloud.google.com/spanner/) result 200).
* [ ] http://cloud.spring.io with 33 occurrences migrated to:  
  https://cloud.spring.io ([https](https://cloud.spring.io) result 200).
* [ ] http://cloud.spring.io/spring-cloud-consul/ with 33 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-consul/ ([https](https://cloud.spring.io/spring-cloud-consul/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 53 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html with 30 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html ([https](https://cloud.spring.io/spring-cloud-netflix/single/spring-cloud-netflix.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html with 6 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html ([https](https://cloud.spring.io/spring-cloud-static/Edgware.SR2/multi/multi__spring_cloud_context_application_context_services.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-static/spring-cloud.html with 8 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud-static/spring-cloud.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html with 78 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html ([https](https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-zookeeper/ with 33 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-zookeeper/ ([https](https://cloud.spring.io/spring-cloud-zookeeper/) result 200).
* [ ] http://curator.apache.org with 26 occurrences migrated to:  
  https://curator.apache.org ([https](https://curator.apache.org) result 200).
* [ ] http://curator.apache.org/curator-x-discovery/ with 26 occurrences migrated to:  
  https://curator.apache.org/curator-x-discovery/ ([https](https://curator.apache.org/curator-x-discovery/) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html with 24 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html with 45 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html ([https](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) result 200).
* [ ] http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html ([https](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html) result 200).
* [ ] http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html with 45 occurrences migrated to:  
  https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html ([https](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) result 200).
* [ ] http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html with 45 occurrences migrated to:  
  https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html ([https](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html) result 200).
* [ ] http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html ([https](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html) result 200).
* [ ] http://docs.confluent.io/2.0.0/kafka/security.html with 22 occurrences migrated to:  
  https://docs.confluent.io/2.0.0/kafka/security.html ([https](https://docs.confluent.io/2.0.0/kafka/security.html) result 200).
* [ ] http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html with 20 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html ([https](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html with 15 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 71 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ with 23 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 33 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html with 20 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html) result 200).
* [ ] http://docssleuth-service1.cfapps.io/start with 18 occurrences migrated to:  
  https://docssleuth-service1.cfapps.io/start ([https](https://docssleuth-service1.cfapps.io/start) result 200).
* [ ] http://en.wikipedia.org/wiki/ACID with 8 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ACID ([https](https://en.wikipedia.org/wiki/ACID) result 200).
* [ ] http://example.com with 33 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.org with 647 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://example.org/ with 70 occurrences migrated to:  
  https://example.org/ ([https](https://example.org/) result 200).
* [ ] http://github.com/spring-cloud/spring-cloud-kubernetes with 7 occurrences migrated to:  
  https://github.com/spring-cloud/spring-cloud-kubernetes ([https](https://github.com/spring-cloud/spring-cloud-kubernetes) result 200).
* [ ] http://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html with 8 occurrences migrated to:  
  https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html ([https](https://googleapis.github.io/googleapis/java/all/latest/apidocs/com/google/cloud/vision/v1/AnnotateImageResponse.html) result 200).
* [ ] http://handlebarsjs.com/ with 27 occurrences migrated to:  
  https://handlebarsjs.com/ ([https](https://handlebarsjs.com/) result 200).
* [ ] http://istio.io with 4 occurrences migrated to:  
  https://istio.io ([https](https://istio.io) result 200).
* [ ] http://kafka.apache.org/090/documentation.html with 44 occurrences migrated to:  
  https://kafka.apache.org/090/documentation.html ([https](https://kafka.apache.org/090/documentation.html) result 200).
* [ ] http://kubernetes.io with 9 occurrences migrated to:  
  https://kubernetes.io ([https](https://kubernetes.io) result 200).
* [ ] http://martinfowler.com/articles/consumerDrivenContracts.html with 35 occurrences migrated to:  
  https://martinfowler.com/articles/consumerDrivenContracts.html ([https](https://martinfowler.com/articles/consumerDrivenContracts.html) result 200).
* [ ] http://martinfowler.com/bliki/CircuitBreaker.html with 35 occurrences migrated to:  
  https://martinfowler.com/bliki/CircuitBreaker.html ([https](https://martinfowler.com/bliki/CircuitBreaker.html) result 200).
* [ ] http://maven.apache.org with 8 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://maven.apache.org/download.cgi with 32 occurrences migrated to:  
  https://maven.apache.org/download.cgi ([https](https://maven.apache.org/download.cgi) result 200).
* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 99 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 64 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://opentracing.io/ with 36 occurrences migrated to:  
  https://opentracing.io/ ([https](https://opentracing.io/) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 363 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://projects.spring.io/spring-cloud/spring-cloud.html with 32 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/spring-cloud.html ([https](https://projects.spring.io/spring-cloud/spring-cloud.html) result 200).
* [ ] http://projects.spring.io/spring-data-redis/ with 8 occurrences migrated to:  
  https://projects.spring.io/spring-data-redis/ ([https](https://projects.spring.io/spring-data-redis/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 16 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://projects.spring.io/spring-integration/ with 33 occurrences migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* [ ] http://projects.spring.io/spring-security/ with 20 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).
* [ ] http://projects.spring.io/spring-session/ with 20 occurrences migrated to:  
  https://projects.spring.io/spring-session/ ([https](https://projects.spring.io/spring-session/) result 200).
* [ ] http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349 with 45 occurrences migrated to:  
  https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349 ([https](https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349) result 200).
* [ ] http://start.spring.io/ with 16 occurrences migrated to:  
  https://start.spring.io/ ([https](https://start.spring.io/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 34 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html with 16 occurrences migrated to:  
  https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html ([https](https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html) result 200).
* [ ] http://www.enterpriseintegrationpatterns.com/ with 31 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/ ([https](https://www.enterpriseintegrationpatterns.com/) result 200).
* [ ] http://www.oracle.com/technetwork/java/javamail/index.html with 8 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javamail/index.html ([https](https://www.oracle.com/technetwork/java/javamail/index.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html with 66 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html with 66 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html with 66 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) result 200).
* [ ] http://www.reactive-streams.org/ with 19 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura with 35 occurrences migrated to:  
  https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura ([https](https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura) result 200).
* [ ] http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27 with 35 occurrences migrated to:  
  https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27 ([https](https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27) result 200).
* [ ] http://www.splunk.com/ with 33 occurrences migrated to:  
  https://www.splunk.com/ ([https](https://www.splunk.com/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 51 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cache/spring-cache.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 35 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 28 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperOver.html with 26 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperOver.html ([https](https://zookeeper.apache.org/doc/current/zookeeperOver.html) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperStarted.html with 26 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperStarted.html ([https](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) result 200).
* [ ] http://cloud.google.com/sdk with 8 occurrences migrated to:  
  https://cloud.google.com/sdk ([https](https://cloud.google.com/sdk) result 301).
* [ ] http://cloud.spring.io/spring-cloud-cli with 35 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-cli ([https](https://cloud.spring.io/spring-cloud-cli) result 301).
* [ ] http://cloud.spring.io/spring-cloud-stream with 15 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream ([https](https://cloud.spring.io/spring-cloud-stream) result 301).
* [ ] http://commons.apache.org/proper/commons-configuration with 35 occurrences migrated to:  
  https://commons.apache.org/proper/commons-configuration ([https](https://commons.apache.org/proper/commons-configuration) result 301).
* [ ] http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html ([https](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html) result 301).
* [ ] http://docs.spring.io with 10 occurrences migrated to:  
  https://docs.spring.io ([https](https://docs.spring.io) result 301).
* [ ] http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java with 35 occurrences migrated to:  
  https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java ([https](https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java) result 301).
* [ ] http://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java with 70 occurrences migrated to:  
  https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java ([https](https://github.com/spring-cloud/spring-cloud-netflix/tree/master/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java) result 301).
* [ ] http://java.oracle.com/ with 2 occurrences migrated to:  
  https://java.oracle.com/ ([https](https://java.oracle.com/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/configmap/ with 9 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/configmap/ ([https](https://kubernetes.io/docs/user-guide/configmap/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/services/ with 9 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/services/ ([https](https://kubernetes.io/docs/user-guide/services/) result 301).
* [ ] http://pact.io/ with 19 occurrences migrated to:  
  https://pact.io/ ([https](https://pact.io/) result 301).
* [ ] http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook with 33 occurrences migrated to:  
  https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook ([https](https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 34 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projects.spring.io/spring-boot with 38 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png with 7 occurrences migrated to:  
  https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png ([https](https://raw.github.com/spring-cloud/spring-cloud-stream-binder-kafka/master/docs/src/main/asciidoc/images/kafka-binder.png) result 301).
* [ ] http://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png with 7 occurrences migrated to:  
  https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png ([https](https://raw.github.com/spring-cloud/spring-cloud-stream-binder-rabbit/master/docs/src/main/asciidoc/images/rabbit-binder.png) result 301).
* [ ] http://research.google.com/pubs/pub36356.html with 33 occurrences migrated to:  
  https://research.google.com/pubs/pub36356.html ([https](https://research.google.com/pubs/pub36356.html) result 301).
* [ ] http://spockframework.github.io/ with 35 occurrences migrated to:  
  https://spockframework.github.io/ ([https](https://spockframework.github.io/) result 301).
* [ ] http://www.sonatype.org/nexus/ with 27 occurrences migrated to:  
  https://www.sonatype.org/nexus/ ([https](https://www.sonatype.org/nexus/) result 301).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html with 45 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html) result 302).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) result 302).
* [ ] http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html with 8 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html ([https](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ManagingCacheClusters.html) result 302).
* [ ] http://docsbrewing-zipkin-server.cfapps.io/ with 30 occurrences migrated to:  
  https://docsbrewing-zipkin-server.cfapps.io/ ([https](https://docsbrewing-zipkin-server.cfapps.io/) result 302).
* [ ] http://docssleuth-zipkin-server.cfapps.io/ with 51 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/ ([https](https://docssleuth-zipkin-server.cfapps.io/) result 302).
* [ ] http://eclipse.org with 26 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 52 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 73 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://repo.spring.io/milestone with 105 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/release with 105 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* [ ] http://repo.spring.io/snapshot with 105 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).
* [ ] http://www.springsource.com/developer/sts with 26 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://%s:%s with 35 occurrences
* http://&lt;host&gt;:&lt;port&gt;/actuator/bindings with 33 occurrences
* http://&lt;host&gt;:&lt;port&gt;/actuator/bindings/myBindingName with 153 occurrences
* http://&lt;server&gt;:&lt;port&gt;/trades with 16 occurrences
* http://&lt;server&gt;:&lt;port&gt;/trades/ with 16 occurrences
* http://&lt;server&gt;:&lt;port&gt;/trades/&lt;trader_id&gt with 16 occurrences
* http://&lt;server&gt;:&lt;port&gt;/trades/&lt;trader_id&gt;,&lt;trade_id&gt with 8 occurrences
* http://127.0.0.1:8200 with 90 occurrences
* http://ATLAS/api/v1/graph?q=name,rest,:eq,:avg with 30 occurrences
* http://ATLAS/api/v1/tags with 15 occurrences
* http://PROD-SVC with 68 occurrences
* http://docbook.org/ns/docbook with 289 occurrences
* http://link/to/your/nexus/or/artifactory/or/sth with 66 occurrences
* http://link/to/your/nexus/or/artifactory/or/sth&lt;/contractsRepositoryUrl&gt with 42 occurrences
* http://loanIssuance/name with 35 occurrences
* http://localhost with 130 occurrences
* http://localhost:12345 with 35 occurrences
* http://localhost:12346 with 35 occurrences
* http://localhost:3001 with 20 occurrences
* http://localhost:5678/configserver with 70 occurrences
* http://localhost:5678/customers with 70 occurrences
* http://localhost:5678/hosts/ with 70 occurrences
* http://localhost:7979 with 10 occurrences
* http://localhost:8000/health.json with 35 occurrences
* http://localhost:8080/customers with 24 occurrences
* http://localhost:8080/flakey with 20 occurrences
* http://localhost:8080/orders with 24 occurrences
* http://localhost:8080/upload with 13 occurrences
* http://localhost:8081 with 64 occurrences
* http://localhost:8081/artifactory/libs-release-local with 104 occurrences
* http://localhost:8081/artifactory/libs-release-local/com/example/bookstore/0.0.1.RELEASE/ with 54 occurrences
* http://localhost:8081/artifactory/libs-release-local/com/example/bookstore/0.0.1.RELEASE/bookstore-0.0.1.RELEASE-stubs.jar with 54 occurrences
* http://localhost:8081/service-registry with 15 occurrences
* http://localhost:8081/service-registry/instance-status with 11 occurrences
* http://localhost:8085 with 57 occurrences
* http://localhost:8085&lt;/contractsRepositoryUrl&gt with 19 occurrences
* http://localhost:8383/turbine.stream?cluster=RACES with 20 occurrences
* http://localhost:8383/turbine.stream?cluster=WEB with 20 occurrences
* http://localhost:8500 with 64 occurrences
* http://localhost:8750 with 10 occurrences
* http://localhost:8750/stubs with 10 occurrences
* http://localhost:8761 with 10 occurrences
* http://localhost:8761/eureka/ with 70 occurrences
* http://localhost:8888 with 148 occurrences
* http://localhost:8888/myapp/default with 45 occurrences
* http://localhost:8888/users with 35 occurrences
* http://localhost:8990/ with 47 occurrences
* http://localhost:9000 with 12 occurrences
* http://localhost:9091 with 10 occurrences
* http://localhost:9095 with 10 occurrences
* http://localhost:9393 with 10 occurrences
* http://localhost:9411 with 10 occurrences
* http://localhost:9411/ with 10 occurrences
* http://localhost:9876/api/books with 54 occurrences
* http://localhost:9994 with 48 occurrences
* http://maven.apache.org/POM/4.0.0 with 128 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 with 198 occurrences
* http://myhost2:9000 with 35 occurrences
* http://myhost:8989 with 70 occurrences
* http://myhost:9000 with 35 occurrences
* http://nameservice with 20 occurrences
* http://nameservice/foo with 40 occurrences
* http://peer1/eureka/ with 35 occurrences
* http://peer1/eureka/,http://peer2/eureka/,http://peer3/eureka/ with 17 occurrences
* http://peer2/eureka/ with 35 occurrences
* http://some/address with 33 occurrences
* http://someNameThatShouldMapFraudDetectionServer/name with 35 occurrences
* http://some_url with 32 occurrences
* http://stores with 18 occurrences
* http://stores/stores with 84 occurrences
* http://testclient/orders/ with 6 occurrences
* http://testclient/orders/1 with 6 occurrences
* http://testeurekabrixtonclient/orders/ with 9 occurrences
* http://testeurekabrixtonclient/orders/1 with 9 occurrences
* http://user:password@localhost:8761/eureka with 70 occurrences
* http://user:password@localhost:8888 with 45 occurrences
* http://www.springframework.org/schema/beans with 126 occurrences
* http://www.springframework.org/schema/cache with 16 occurrences
* http://www.springframework.org/schema/cloud/aws/cache with 16 occurrences
* http://www.springframework.org/schema/cloud/aws/context with 64 occurrences
* http://www.springframework.org/schema/cloud/aws/jdbc with 16 occurrences
* http://www.springframework.org/schema/cloud/aws/mail with 16 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging with 16 occurrences
* http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging with 8 occurrences
* http://www.springframework.org/schema/integration with 70 occurrences
* http://www.w3.org/1999/xlink with 289 occurrences
* http://www.w3.org/2000/svg with 28 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 238 occurrences
* http://zipkinserver/ with 40 occurrences